### PR TITLE
Fix MCP documentation fetch

### DIFF
--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -27,8 +27,7 @@ export function createMcpServer() {
         const normalizedPath = normalizeDocumentationPath(decodedPath)
         const appleUrl = generateAppleDocUrl(normalizedPath)
 
-        const documentationPath = `/documentation/${decodedPath}`
-        const jsonData = await fetchJSONData(documentationPath)
+        const jsonData = await fetchJSONData(normalizedPath)
         const markdown = await renderFromJSON(jsonData, appleUrl)
 
         if (!markdown || markdown.trim().length < 100) {
@@ -188,8 +187,7 @@ export function createMcpServer() {
         const normalizedPath = normalizeDocumentationPath(path)
         const appleUrl = generateAppleDocUrl(normalizedPath)
 
-        const documentationPath = `/documentation/${path}`
-        const jsonData = await fetchJSONData(documentationPath)
+        const jsonData = await fetchJSONData(normalizedPath)
         const markdown = await renderFromJSON(jsonData, appleUrl)
 
         if (!markdown || markdown.trim().length < 100) {


### PR DESCRIPTION
Not sure if you're ready for contributions yet but thought I'd submit this one to fix a minor issue.

### The Problem

When I tested the MCP server, it kept returning 404s when using the `fetch` tool with a path like `/documentation/swift/task/`:

```
⏺ sosumi - fetch (MCP)(path: "/documentation/swift/task/")
  ⎿  Error fetching documentation for "/documentation/swift/task/": Failed to fetch JSON: 404 Not Found
```

### Code Changes

Used the `normalizedPath` for `fetchJSONData` in the `documentation` resource handler and the `fetch` tool. The current code ends up doubling up the `documentation` path components producing `documentation/documentation/swiftui/view` when calling `fetchJSONData`.

Probably several other ways to do this but this seemed simplest for now.

### After

```
⏺ sosumi - fetch (MCP)(path: "swift/array")
  ⎿  ---
     title: Array
     description: An ordered, random-access collection.

⏺ sosumi - fetch (MCP)(path: "documentation/swift/array")
  ⎿  ---
     title: Array
     description: An ordered, random-access collection.
```

I also briefly checked the Resource loader using [MCP Inspector](https://github.com/modelcontextprotocol/inspector) and both `doc://documentation/swift/array` and `doc://swift/array` work.