### PR TITLE
Update MCP resource template and tool names

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -159,6 +159,10 @@
             list-style: none;
         }
 
+        #mcp ul li {
+            margin-bottom: 1rem;
+        }
+
         #mcp dd {
             color: var(--text-secondary);
         }
@@ -474,7 +478,7 @@
                 <ul>
                     <li>
                         <dl>
-                            <dt><code>search</code></dt>
+                            <dt><code>searchAppleDocumentation</code></dt>
                             <dd><strong>Search Apple Developer documentation</strong>
                                 <br>Parameters: <code>query</code> (string)
                                 <br><em>Returns structured results with titles, URLs, descriptions, breadcrumbs, and
@@ -484,7 +488,7 @@
                     </li>
                     <li>
                         <dl>
-                            <dt><code>fetch</code></dt>
+                            <dt><code>fetchAppleDocumentation</code></dt>
                             <dd><strong>Fetch Apple Developer documentation by path</strong>
                                 <br>Parameters: <code>path</code> (string) - Full or relative documentation path
                                 <br><em>Returns documentation content as markdown</em>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -5,9 +5,9 @@ It might not be their fault!
 
 Apple Developer docs are locked behind JavaScript,
 making them invisible to most LLMs.
-If they try to fetch it, all they see is
-"This page requires JavaScript.
-Please turn on JavaScript in your browser and refresh the page to view its content."
+If they try to fetch it, all they see is:
+> This page requires JavaScript.
+> Please turn on JavaScript in your browser and refresh the page to view its content.
 
 This service translates Apple Developer documentation pages into AI-friendly Markdown.
 
@@ -51,7 +51,7 @@ Connect your MCP client to `https://sosumi.ai/mcp`:
 
 ### Available Tools
 
-- `search` - Search Apple Developer documentation
+- `searchAppleDocumentation` - Search Apple Developer documentation
   - Parameters: `query` (string)
   - Returns structured results with titles,
     URLs,
@@ -59,7 +59,7 @@ Connect your MCP client to `https://sosumi.ai/mcp`:
     breadcrumbs,
     and tags
 
-- `fetch` - Fetch Apple Developer documentation by path
+- `fetchAppleDocumentation` - Fetch Apple Developer documentation by path
   - Parameters: `path` (string) - Full or relative documentation path
   - Returns documentation content as markdown
 

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -14,7 +14,7 @@ export function createMcpServer() {
 
   // Register doc://{path} resource template
   server.registerResource(
-    "documentation",
+    "appleDocumentation",
     new ResourceTemplate("doc://{path}", { list: undefined }),
     {
       title: "Apple Documentation",
@@ -60,7 +60,7 @@ export function createMcpServer() {
 
   // Register Apple search tool
   server.registerTool(
-    "search",
+    "searchAppleDocumentation",
     {
       title: "Search Apple Documentation",
       description: "Search Apple Developer documentation and return structured results",
@@ -163,7 +163,7 @@ export function createMcpServer() {
 
   // Register documentation fetch tool (complements resource template for tool-only clients)
   server.registerTool(
-    "fetch",
+    "fetchAppleDocumentation",
     {
       title: "Fetch Apple Documentation",
       description: "Fetch Apple Developer documentation by path and return as markdown",


### PR DESCRIPTION
This kind of namespacing _shouldn't_ be necessary, but:

- LLMs seem to weigh tool calling decision more heavily on tool names than they probably should 
- Clients don't always do the right thing when resolving tool names against multiple MCP servers [^1]
- Clients may present ambiguous tool name to user instead of title 

[^1]: https://forum.cursor.com/t/mcp-tools-name-collision-causing-cross-service-tool-call-failures/70946/2