### PR TITLE
Fix repository URL case in Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Sosumi.ai is currently hosted by
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/nshipster/sosumi.ai.git
+   git clone https://github.com/NSHipster/sosumi.ai.git
    cd sosumi.ai
    ```
 


### PR DESCRIPTION
This PR corrects the repository URL in the Quick Start instructions.

## Change
Changed `https://github.com/nshipster/sosumi.ai.git` to `https://github.com/NSHipster/sosumi.ai.git`

## Reasoning
While GitHub URLs are case-insensitive and both work, using the canonical organization name "NSHipster" (with capital letters) maintains consistency with:
- The actual organization name on GitHub
- The repository's remote URL
- Professional documentation standards

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>