### PR TITLE
Add table rendering for Apple doc JSON

### DIFF
--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -264,6 +264,52 @@ describe("Render Function", () => {
     })
   })
 
+  describe("Table rendering", () => {
+    it("should render tables with header row and body rows", async () => {
+      const data = {
+        metadata: { title: "Import Options" },
+        primaryContentSections: [
+          {
+            kind: "content",
+            content: [
+              {
+                type: "table",
+                header: "row",
+                rows: [
+                  [
+                    [{ type: "paragraph", inlineContent: [{ type: "text", text: "Attributes" }] }],
+                    [{ type: "paragraph", inlineContent: [{ type: "text", text: "Description" }] }],
+                  ],
+                  [
+                    [
+                      {
+                        type: "paragraph",
+                        inlineContent: [{ type: "codeVoice", code: "key" }],
+                      },
+                    ],
+                    [
+                      {
+                        type: "paragraph",
+                        inlineContent: [
+                          { type: "text", text: "The value for the import option." },
+                        ],
+                      },
+                    ],
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+      }
+
+      const result = await renderFromJSON(data as any, "https://test.com")
+      expect(result).toContain("| Attributes | Description |")
+      expect(result).toContain("| --- | --- |")
+      expect(result).toContain("| `key` | The value for the import option. |")
+    })
+  })
+
   describe("URL Conversion", () => {
     it("should convert SwiftUI doc identifiers to proper URLs", async () => {
       const data = {


### PR DESCRIPTION
Resolves #26 

On pages like https://developer.apple.com/documentation/professional-video-applications/import-options, Sosumi.ai wasn't rendering table content  (https://sosumi.ai/documentation/professional-video-applications/import-options?language=objc).

This PR adds code to render tables in GFM / CommonMark format.

```diff
  ## Overview
  
  The `import-options` element can contain zero or more `option` elements. The `option` element describes options for importing events and projects into Final Cut Pro through the key-value pair in the attributes listed below.
  
+ | Attributes | Description |
+ | --- | --- |
+ | `key` | A string that identifies one of the following import options:  `copy assets`: Copy or link assets referenced in the imported XML. Valid values are `1` (copy) and `0` (link).    `library location`: Specifies the location (URL) of the library to which to add the event or project. If the specified URL represents a directory, Final Cut Pro uses the default library name. If no library exists at the location specified in the XML, Final Cut Pro creates a new library.  `suppress warnings`: Suppress or show warnings generated during import. Valid values are `≥1` (suppress) and `0` (show)   `base url`: A URL to resolve a relative URL given in the XML as the value of the `src` attribute of a `resources` element. |
+ | `value` | The value for the import option. |
```