### PR TITLE
Fall back to root domain robots.txt when subdomain returns 404/403

### DIFF
--- a/src/lib/external/fetch.ts
+++ b/src/lib/external/fetch.ts
@@ -91,13 +91,13 @@ export async function fetchRobotsPolicy(
     },
   })
 
-  // Missing robots.txt is treated as no policy restrictions.
-  if (response.status === 404 || response.status === 410) {
-    return { kind: "allow-all" }
+  // Missing or inaccessible robots.txt — caller may try root domain or allow.
+  if (response.status === 404 || response.status === 410 || response.status === 403) {
+    return { kind: "not-found" }
   }
 
-  // Explicit access denial when robots cannot be read due to auth restrictions.
-  if (response.status === 401 || response.status === 403) {
+  // Explicit access denial when robots cannot be read due to auth.
+  if (response.status === 401) {
     return { kind: "deny-all" }
   }
 

--- a/src/lib/external/types.ts
+++ b/src/lib/external/types.ts
@@ -1,6 +1,7 @@
 export type RobotsPolicyResult =
   | { kind: "allow-all" }
   | { kind: "deny-all" }
+  | { kind: "not-found" }
   | { kind: "rules"; robotsText: string }
 
 export interface ExternalPolicyEnv {


### PR DESCRIPTION
Resolves #28
Follow-up to #29  

If subdomain `robots.txt` is missing or inaccessible (404, 410, 403), fetch root domain's `robots.txt` and use it; allow fetch when neither resolves.