### PR TITLE
Remove MCP `doc://` resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,6 @@ you can run this command to proxy over stdio:
 
 See [the website](https://sosumi.ai/#clients) for client-specific instructions.
 
-#### Available Resources
-
-- `doc://{path}` - Apple Developer documentation and Human Interface Guidelines in Markdown format
-  - Example: `doc://swift/array` returns Swift Array documentation
-  - Example: `doc://design/human-interface-guidelines/foundations/color` returns HIG Color guidelines
-
 #### Available Tools
 
 - `searchAppleDocumentation` - Searches Apple Developer documentation

--- a/public/index.html
+++ b/public/index.html
@@ -765,21 +765,6 @@
             </header>
 
 
-            <div class="resources">
-                <h3>Available Resources</h3>
-                <ul>
-                    <li>
-                        <dl>
-                            <dt><code>doc://{path}</code></dt>
-                            <dd><strong>Apple Developer documentation and Human Interface Guidelines in Markdown format</strong>
-                                <br><em>Example: <code>doc://swift/array</code> returns Swift Array documentation</em>
-                                <br><em>Example: <code>doc://design/human-interface-guidelines/foundations/color</code> returns HIG Color guidelines</em>
-                            </dd>
-                        </dl>
-                    </li>
-                </ul>
-            </div>
-
             <div class="tools">
                 <h3>Available Tools</h3>
                 <ul>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -109,12 +109,6 @@ you can run this command to proxy over stdio:
 }
 ```
 
-### Available Resources
-
-- `doc://{path}` - Apple Developer documentation and Human Interface Guidelines in Markdown format
-  - Example: `doc://swift/array` returns Swift Array documentation
-  - Example: `doc://design/human-interface-guidelines/foundations/color` returns HIG Color guidelines
-
 ### Available Tools
 
 - `searchAppleDocumentation` - Searches Apple Developer documentation

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -1,4 +1,4 @@
-import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { z } from "zod"
 
 import type { ExternalPolicyEnv } from "./external"
@@ -14,78 +14,6 @@ export function createMcpServer(externalPolicyEnv: ExternalPolicyEnv = {}) {
     name: "sosumi.ai",
     version: "1.0.0",
   })
-
-  // Register doc://{path} resource template (supports both dev docs and HIG)
-  server.registerResource(
-    "appleDocumentation",
-    new ResourceTemplate("doc://{path}", { list: undefined }),
-    {
-      title: "Apple Documentation",
-      description: "Apple Developer documentation and Human Interface Guidelines as Markdown",
-    },
-    async (uri, { path }) => {
-      try {
-        // Percent decode the path first
-        const decodedPath = decodeURIComponent(path.toString())
-
-        // Check if this is a HIG path
-        if (decodedPath.includes("design/human-interface-guidelines")) {
-          // Handle HIG content
-          const higPath = decodedPath.replace(/^\/?(design\/human-interface-guidelines\/)/, "")
-          const sourceUrl = `https://developer.apple.com/design/human-interface-guidelines/${higPath}`
-
-          const jsonData = await fetchHIGPageData(higPath)
-          const markdown = await renderHIGFromJSON(jsonData, sourceUrl)
-
-          if (!markdown || markdown.trim().length < 100) {
-            throw new Error("Insufficient content in HIG page")
-          }
-
-          return {
-            contents: [
-              {
-                uri: uri.href,
-                text: markdown,
-                mimeType: "text/markdown",
-              },
-            ],
-          }
-        } else {
-          // Handle regular developer documentation
-          const normalizedPath = normalizeDocumentationPath(decodedPath)
-          const appleUrl = generateAppleDocUrl(normalizedPath)
-
-          const jsonData = await fetchJSONData(normalizedPath)
-          const markdown = await renderFromJSON(jsonData, appleUrl)
-
-          if (!markdown || markdown.trim().length < 100) {
-            throw new Error("Insufficient content in documentation")
-          }
-
-          return {
-            contents: [
-              {
-                uri: uri.href,
-                text: markdown,
-                mimeType: "text/markdown",
-              },
-            ],
-          }
-        }
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error"
-        return {
-          contents: [
-            {
-              uri: uri.href,
-              text: `Error fetching content: ${errorMessage}`,
-              mimeType: "text/plain",
-            },
-          ],
-        }
-      }
-    },
-  )
 
   // Register Apple search tool
   server.registerTool(

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -5,8 +5,6 @@ const fetchVideoTranscriptMarkdown = vi.fn()
 
 vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => {
   class McpServerMock {
-    registerResource() {}
-
     registerTool(
       name: string,
       _config: unknown,
@@ -16,11 +14,8 @@ vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => {
     }
   }
 
-  class ResourceTemplateMock {}
-
   return {
     McpServer: McpServerMock,
-    ResourceTemplate: ResourceTemplateMock,
   }
 })
 


### PR DESCRIPTION
MCP client support for resources is inconsistent, and most that do support resources prefer tools instead.