### PR TITLE
feat: add full HIG markdown export script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ lerna-debug.log*
 
 # misc
 .DS_Store
+out/
 
 .dev.vars*
 !.dev.vars.example

--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ npm run test:ui       # Run tests with UI
 npm run test:run      # Run tests once
 ```
 
+### Full HIG Export
+
+If you want one local Markdown file containing all Human Interface Guidelines pages:
+
+```bash
+npm run export:hig:full
+```
+
+Output: `out/human-interface-guidelines-full.md`
+
 ### Code Quality
 
 This project uses [Biome](https://biomejs.dev/) 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy --minify",
     "cf-typegen": "wrangler types --env-interface CloudflareBindings",
+    "export:hig:full": "node scripts/export-hig-full-md.mjs",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",

--- a/scripts/export-hig-full-md.mjs
+++ b/scripts/export-hig-full-md.mjs
@@ -1,0 +1,49 @@
+import fs from 'node:fs/promises';
+
+const tocUrl = 'https://developer.apple.com/tutorials/data/index/design--human-interface-guidelines';
+const basePageUrl = 'https://sosumi.ai/design/human-interface-guidelines';
+
+function collectPaths(items, out = []) {
+  for (const item of items || []) {
+    if (item?.path) {
+      const normalized = item.path.replace(/^\/design\/human-interface-guidelines\/?/, '').replace(/^\/+|\/+$/g, '');
+      if (normalized) out.push(normalized);
+    }
+    if (item?.children?.length) collectPaths(item.children, out);
+  }
+  return out;
+}
+
+const tocRes = await fetch(tocUrl, { headers: { Accept: 'application/json' } });
+if (!tocRes.ok) throw new Error(`Failed to fetch ToC: ${tocRes.status}`);
+const toc = await tocRes.json();
+
+const uniquePaths = [...new Set(collectPaths(toc?.interfaceLanguages?.swift || []))];
+
+let output = '';
+output += '# Human Interface Guidelines (Complete Export)\n\n';
+output += `Source index: https://developer.apple.com/design/human-interface-guidelines/\n`;
+output += `Generated: ${new Date().toISOString()}\n\n`;
+output += `Total pages: ${uniquePaths.length}\n\n`;
+output += '---\n\n';
+
+for (let i = 0; i < uniquePaths.length; i += 1) {
+  const p = uniquePaths[i];
+  const url = `${basePageUrl}/${p}`;
+  const res = await fetch(url, { headers: { Accept: 'text/markdown' } });
+  if (!res.ok) {
+    output += `## ${p}\n\n`;
+    output += `Failed to fetch: ${url} (${res.status})\n\n---\n\n`;
+    continue;
+  }
+  const md = (await res.text()).trim();
+  output += `<!-- PAGE ${i + 1}/${uniquePaths.length}: ${p} -->\n\n`;
+  output += md;
+  output += '\n\n---\n\n';
+  process.stderr.write(`Fetched ${i + 1}/${uniquePaths.length}: ${p}\n`);
+}
+
+const outPath = 'out/human-interface-guidelines-full.md';
+await fs.mkdir('out', { recursive: true });
+await fs.writeFile(outPath, output, 'utf8');
+console.log(outPath);


### PR DESCRIPTION
Adding a small offline exporter for users who need the entire Human Interface Guidelines into one Markdown file.

- Add npm script: `export:hig:full`, `scripts/export-hig-full-md.mjs`
- Document cmd in README, ignore generated `out/` artifacts

Other routes should be unchanged.

Cheers! 🤍