### PR TITLE
Publish Sosumi skill discovery endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,38 +2,42 @@
 
 Making Apple docs AI-readable.
 
-[sosumi.ai](https://sosumi.ai) 
-provides Apple Developer documentation in an AI-readable format 
+[sosumi.ai](https://sosumi.ai)
+provides Apple Developer documentation in an AI-readable format
 by converting JavaScript-rendered pages into Markdown.
 
 ## Usage
 
 ### HTTP API
 
-Replace `developer.apple.com` with `sosumi.ai` 
+Replace `developer.apple.com` with `sosumi.ai`
 in any Apple Developer documentation URL:
 
 **Original:**
+
 ```
 https://developer.apple.com/documentation/swift/array
 ```
 
 **AI-readable:**
+
 ```
 https://sosumi.ai/documentation/swift/array
 ```
 
-This works for all API reference docs, 
+This works for all API reference docs,
 as well as Apple's [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/) (HIG).
 
 WWDC session transcripts are also supported by replacing the same host for video URLs:
 
 **Original:**
+
 ```
 https://developer.apple.com/videos/play/wwdc2021/10133/
 ```
 
 **AI-readable:**
+
 ```
 https://sosumi.ai/videos/play/wwdc2021/10133
 ```
@@ -41,11 +45,13 @@ https://sosumi.ai/videos/play/wwdc2021/10133
 Sosumi can also proxy public non-Apple Swift-DocC pages using:
 
 **Original:**
+
 ```
 https://apple.github.io/swift-argument-parser/documentation/argumentparser
 ```
 
 **AI-readable:**
+
 ```
 https://sosumi.ai/external/https://apple.github.io/swift-argument-parser/documentation/argumentparser
 ```
@@ -60,8 +66,8 @@ https://sosumi.ai/external/https://apple.github.io/swift-argument-parser/documen
 
 ### MCP Integration
 
-Sosumi's MCP server supports Streamable HTTP and Server-Sent Events (SSE) transport. 
-If your client supports either of these, 
+Sosumi's MCP server supports Streamable HTTP and Server-Sent Events (SSE) transport.
+If your client supports either of these,
 configure it to connect directly to `https://sosumi.ai/mcp`.
 
 Otherwise,
@@ -154,11 +160,17 @@ Want your AI coding assistant to use Sosumi consistently?
 Use the hosted skill file:
 [`https://sosumi.ai/SKILL.md`](https://sosumi.ai/SKILL.md)
 
+Spec-compliant clients can also install it with:
+
+```bash
+npx skills add https://sosumi.ai
+```
+
 ### Chrome Extension
 
-You can also use Sosumi from a community-contributed 
+You can also use Sosumi from a community-contributed
 [Chrome extension](https://chromewebstore.google.com/detail/donffakeimppgoehccpfhlchmbfdmfpj?utm_source=item-share-cb),
-which adds a "Copy sosumi Link" button 
+which adds a "Copy sosumi Link" button
 to Apple Developer documentation pages.
 [Source code](https://github.com/FromAtom/Link-Generator-for-sosumi.ai) is available on GitHub.
 
@@ -167,11 +179,11 @@ to Apple Developer documentation pages.
 This project is designed to be easily run on your own machine
 or deployed to a hosting provider.
 
-Sosumi.ai is currently hosted by 
+Sosumi.ai is currently hosted by
 [Cloudflare Workers](https://workers.cloudflare.com).
 
 > [!NOTE]  
-> The application is built with Hono, 
+> The application is built with Hono,
 > making it compatible with various runtimes.
 >
 > See the [Hono docs](https://hono.dev/docs/getting-started/basic)
@@ -185,17 +197,20 @@ Sosumi.ai is currently hosted by
 ### Quick Start
 
 1. **Clone the repository:**
+
    ```bash
    git clone https://github.com/nshipster/sosumi.ai.git
    cd sosumi.ai
    ```
 
 2. **Install dependencies:**
+
    ```bash
    npm install
    ```
 
 3. **Start development server:**
+
    ```bash
    npm run dev
    ```
@@ -203,7 +218,7 @@ Sosumi.ai is currently hosted by
 Once the application is up and running, press the <kbd>b</kbd>
 to open the URL in your browser.
 
-To configure MCP clients to use your development server, 
+To configure MCP clients to use your development server,
 replace `sosumi.ai` with the local server address
 (`http://localhost:8787` by default).
 
@@ -233,7 +248,7 @@ npm run test:run      # Run tests once
 ```
 
 > [!TIP]
-> When running the CLI through npm scripts during local development, 
+> When running the CLI through npm scripts during local development,
 > use `-s` (`--silent`)
 > to suppress npm's script preamble so output pipes cleanly:
 >
@@ -243,7 +258,7 @@ npm run test:run      # Run tests once
 
 ### Code Quality
 
-This project uses [Biome](https://biomejs.dev/) 
+This project uses [Biome](https://biomejs.dev/)
 for code formatting, linting, and import organization.
 
 - `npm run format` - Format all code files
@@ -261,7 +276,7 @@ For the best development experience, install the Biome extension for your editor
 
 ### Cloudflare Workers
 
-Whenever you update your `wrangler.toml` or change your Worker bindings, 
+Whenever you update your `wrangler.toml` or change your Worker bindings,
 be sure to re-run:
 
 ```bash

--- a/public/index.html
+++ b/public/index.html
@@ -944,6 +944,10 @@ sosumi serve --port 8787</code></pre>
                     Teach your coding assistant to use Sosumi consistently with:
                     <code class="no-wrap"><a href="https://sosumi.ai/SKILL.md">https://sosumi.ai/SKILL.md</a></code>
                 </p>
+                <p>
+                    Spec-compliant clients can also discover the skill from this domain:
+                </p>
+                <pre><code>npx skills add https://sosumi.ai</code></pre>
             </header>
 
             <div class="skill-tabs">

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -12,7 +12,7 @@ If they try to fetch it, all they see is:
 This service translates Apple Developer documentation,
 Human Interface Guidelines, WWDC sessions,
 and external Swift-DocC sites into AI-friendly Markdown.
-Access it in your browser, over MCP, from the command line, as an AI skill, 
+Access it in your browser, over MCP, from the command line, as an AI skill,
 or with an unofficial [Chrome extension](https://chromewebstore.google.com/detail/donffakeimppgoehccpfhlchmbfdmfpj).
 
 ## HTTP Usage
@@ -20,19 +20,19 @@ or with an unofficial [Chrome extension](https://chromewebstore.google.com/detai
 Replace `developer.apple.com` with `sosumi.ai`:
 
 **Original:**
-https://developer.apple.com/documentation/swift/array
+<https://developer.apple.com/documentation/swift/array>
 
 **AI-readable:**
-https://sosumi.ai/documentation/swift/array
+<https://sosumi.ai/documentation/swift/array>
 
 ### Examples
 
-- Swift: https://sosumi.ai/documentation/swift
-- SwiftUI: https://sosumi.ai/documentation/swiftui
-- Human Interface Guidelines: https://sosumi.ai/design/human-interface-guidelines
-- WWDC21 — Protect mutable state with Swift actors: https://sosumi.ai/videos/play/wwdc2021/10133
-- Swift Argument Parser (GitHub Pages): https://sosumi.ai/external/https://apple.github.io/swift-argument-parser/documentation/argumentparser/
-- The Composable Architecture (Swift Package Index): https://sosumi.ai/external/https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/1.23.1/documentation/composablearchitecture
+- Swift: <https://sosumi.ai/documentation/swift>
+- SwiftUI: <https://sosumi.ai/documentation/swiftui>
+- Human Interface Guidelines: <https://sosumi.ai/design/human-interface-guidelines>
+- WWDC21 — Protect mutable state with Swift actors: <https://sosumi.ai/videos/play/wwdc2021/10133>
+- Swift Argument Parser (GitHub Pages): <https://sosumi.ai/external/https://apple.github.io/swift-argument-parser/documentation/argumentparser/>
+- The Composable Architecture (Swift Package Index): <https://sosumi.ai/external/https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/1.23.1/documentation/composablearchitecture>
 
 ## MCP Usage
 
@@ -129,7 +129,7 @@ you can run this command to proxy over stdio:
   - Returns content as Markdown
 
 - `fetchExternalDocumentation` - Fetches external Swift-DocC documentation by absolute HTTPS URL
-  - Parameters: `url` (string) - External URL (e.g., 'https://apple.github.io/swift-argument-parser/documentation/argumentparser')
+  - Parameters: `url` (string) - External URL (e.g., '<https://apple.github.io/swift-argument-parser/documentation/argumentparser>')
   - Returns content as Markdown
 
 ### Troubleshooting
@@ -252,6 +252,12 @@ sosumi serve --port 8787
 Teach your coding assistant to use Sosumi consistently with:
 `https://sosumi.ai/SKILL.md`
 
+Spec-compliant clients can also discover and install it from this domain:
+
+```bash
+npx skills add https://sosumi.ai
+```
+
 ### Claude Code
 
 Install as a reusable skill (personal or project-level):
@@ -329,4 +335,4 @@ Fetches are made with the user agent `sosumi-ai/1.0 (+https://sosumi.ai/#bot)`.
 For external Swift-DocC hosts, sosumi honors `robots.txt` rules
 and opt-out response directives such as `X-Robots-Tag: noai`.
 
-**Contact:** info@sosumi.ai
+**Contact:** <info@sosumi.ai>

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,13 +36,13 @@ interface Env {
 const skillName = "sosumi"
 const skillHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Cache-Control": "public, max-age=300",
+  "Cache-Control": "public, max-age=300, s-maxage=600",
   "Content-Type": "text/markdown; charset=utf-8",
 }
 
 const skillIndexHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Cache-Control": "public, max-age=300",
+  "Cache-Control": "public, max-age=300, s-maxage=600",
   "Content-Type": "application/json; charset=utf-8",
 }
 
@@ -96,34 +96,33 @@ app.all("/.well-known/agent-skills/index.json", async (c) => {
     return c.text("Method Not Allowed", 405, { Allow: "GET, HEAD" })
   }
 
+  const skill = await loadSkill(c)
+
   if (c.req.method === "HEAD") {
-    await assertSkillAssetExists(c)
     return new Response(null, {
       status: 200,
       headers: skillIndexHeaders,
     })
   }
 
-  const skill = await loadSkill(c)
   const index = await createSkillIndex(skill)
 
   return c.json(index, 200, skillIndexHeaders)
 })
 
-app.all("/.well-known/agent-skills/sosumi/SKILL.md", async (c) => {
+app.all(`/.well-known/agent-skills/${skillName}/SKILL.md`, async (c) => {
   if (c.req.method !== "GET" && c.req.method !== "HEAD") {
     return c.text("Method Not Allowed", 405, { Allow: "GET, HEAD" })
   }
 
+  const skill = await loadSkill(c)
+
   if (c.req.method === "HEAD") {
-    await assertSkillAssetExists(c)
     return new Response(null, {
       status: 200,
       headers: skillHeaders,
     })
   }
-
-  const skill = await loadSkill(c)
 
   return new Response(skill.bytes, {
     status: 200,
@@ -575,19 +574,6 @@ interface SkillArtifact {
   bytes: ArrayBuffer
   description: string
   name: string
-}
-
-async function assertSkillAssetExists(c: Context<{ Bindings: Env }>): Promise<void> {
-  const skillUrl = new URL("/SKILL.md", c.req.url)
-  const headResponse = await c.env.ASSETS.fetch(
-    new Request(skillUrl.toString(), { method: "HEAD" }),
-  )
-
-  if (!headResponse.ok) {
-    throw new HTTPException(500, {
-      message: "Failed to load SKILL.md",
-    })
-  }
 }
 
 async function loadSkill(c: Context<{ Bindings: Env }>): Promise<SkillArtifact> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { StreamableHTTPTransport } from "@hono/mcp"
+import type { Context } from "hono"
 import { Hono } from "hono"
 import { accepts } from "hono/accepts"
 import { cache } from "hono/cache"
@@ -30,6 +31,19 @@ interface Env {
   NODE_ENV: string
   EXTERNAL_DOC_HOST_ALLOWLIST?: string
   EXTERNAL_DOC_HOST_BLOCKLIST?: string
+}
+
+const skillName = "sosumi"
+const skillHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Cache-Control": "public, max-age=300",
+  "Content-Type": "text/markdown; charset=utf-8",
+}
+
+const skillIndexHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Cache-Control": "public, max-age=300",
+  "Content-Type": "application/json; charset=utf-8",
 }
 
 const app = new Hono<{ Bindings: Env }>()
@@ -75,6 +89,44 @@ app.all("/mcp", async (c) => {
   const transport = new StreamableHTTPTransport()
   await mcpServer.connect(transport)
   return transport.handleRequest(c)
+})
+
+app.all("/.well-known/agent-skills/index.json", async (c) => {
+  if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+    return c.text("Method Not Allowed", 405, { Allow: "GET, HEAD" })
+  }
+
+  const skill = await loadSkill(c)
+  const index = await createSkillIndex(skill)
+
+  if (c.req.method === "HEAD") {
+    return new Response(null, {
+      status: 200,
+      headers: skillIndexHeaders,
+    })
+  }
+
+  return c.json(index, 200, skillIndexHeaders)
+})
+
+app.all("/.well-known/agent-skills/sosumi/SKILL.md", async (c) => {
+  if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+    return c.text("Method Not Allowed", 405, { Allow: "GET, HEAD" })
+  }
+
+  const skill = await loadSkill(c)
+
+  if (c.req.method === "HEAD") {
+    return new Response(null, {
+      status: 200,
+      headers: skillHeaders,
+    })
+  }
+
+  return new Response(skill.bytes, {
+    status: 200,
+    headers: skillHeaders,
+  })
 })
 
 app.get("/", async (c) => {
@@ -516,5 +568,124 @@ If this issue persists, please report it to <info@sosumi.ai>.
     { "Content-Type": "text/markdown; charset=utf-8" },
   )
 })
+
+interface SkillArtifact {
+  bytes: ArrayBuffer
+  description: string
+  name: string
+}
+
+async function loadSkill(c: Context<{ Bindings: Env }>): Promise<SkillArtifact> {
+  const skillUrl = new URL("/SKILL.md", c.req.url)
+  const skillResponse = await c.env.ASSETS.fetch(new Request(skillUrl.toString()))
+
+  if (!skillResponse.ok) {
+    throw new HTTPException(500, {
+      message: "Failed to load SKILL.md",
+    })
+  }
+
+  const bytes = await skillResponse.arrayBuffer()
+  const frontmatter = parseSkillFrontmatter(new TextDecoder().decode(bytes))
+
+  assertValidSkillFrontmatter(frontmatter)
+
+  return {
+    bytes,
+    description: frontmatter.description,
+    name: frontmatter.name,
+  }
+}
+
+async function createSkillIndex(skill: SkillArtifact) {
+  return {
+    $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+    skills: [
+      {
+        name: skill.name,
+        type: "skill-md",
+        description: skill.description,
+        url: `/.well-known/agent-skills/${skill.name}/SKILL.md`,
+        digest: `sha256:${await sha256Hex(skill.bytes)}`,
+        files: ["SKILL.md"],
+      },
+    ],
+  }
+}
+
+function parseSkillFrontmatter(markdown: string): Record<string, string> {
+  const match = markdown.match(/^---\n([\s\S]*?)\n---\n/)
+
+  if (!match) {
+    throw new HTTPException(500, {
+      message: "SKILL.md must start with YAML frontmatter.",
+    })
+  }
+
+  const fields: Record<string, string> = {}
+
+  for (const line of match[1].split("\n")) {
+    if (!line.trim()) {
+      continue
+    }
+
+    const separator = line.indexOf(":")
+
+    if (separator === -1) {
+      throw new HTTPException(500, {
+        message: `Invalid SKILL.md frontmatter line: ${line}`,
+      })
+    }
+
+    const key = line.slice(0, separator).trim()
+    const value = line.slice(separator + 1).trim()
+
+    fields[key] = stripQuotes(value)
+  }
+
+  return fields
+}
+
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1)
+  }
+
+  return value
+}
+
+function assertValidSkillFrontmatter(frontmatter: Record<string, string>) {
+  if (frontmatter.name !== skillName) {
+    throw new HTTPException(500, {
+      message: `Expected skill name "${skillName}", got "${frontmatter.name ?? ""}".`,
+    })
+  }
+
+  if (!/^[a-z0-9](?:-?[a-z0-9])*$/.test(frontmatter.name) || frontmatter.name.length > 64) {
+    throw new HTTPException(500, {
+      message: `Invalid skill name: ${frontmatter.name}`,
+    })
+  }
+
+  if (frontmatter.description.length === 0) {
+    throw new HTTPException(500, {
+      message: "Skill description is required.",
+    })
+  }
+
+  if (frontmatter.description.length > 1024) {
+    throw new HTTPException(500, {
+      message: "Skill description must be 1024 characters or fewer.",
+    })
+  }
+}
+
+async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("")
+}
 
 export default app

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { StreamableHTTPTransport } from "@hono/mcp"
-import type { Context } from "hono"
 import { Hono } from "hono"
 import { accepts } from "hono/accepts"
 import { cache } from "hono/cache"
@@ -23,6 +22,13 @@ import {
 import { createMcpServer } from "./lib/mcp"
 import { fetchJSONData, renderFromJSON } from "./lib/reference"
 import { searchAppleDeveloperDocs } from "./lib/search"
+import {
+  createSkillIndex,
+  loadSkill,
+  SKILL_NAME,
+  skillHeaders,
+  skillIndexHeaders,
+} from "./lib/skill"
 import { generateAppleDocUrl, isValidAppleDocUrl, normalizeDocumentationPath } from "./lib/url"
 import { fetchVideoTranscriptMarkdown, TranscriptNotFoundError } from "./lib/video"
 
@@ -31,19 +37,6 @@ interface Env {
   NODE_ENV: string
   EXTERNAL_DOC_HOST_ALLOWLIST?: string
   EXTERNAL_DOC_HOST_BLOCKLIST?: string
-}
-
-const skillName = "sosumi"
-const skillHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Cache-Control": "public, max-age=300, s-maxage=600",
-  "Content-Type": "text/markdown; charset=utf-8",
-}
-
-const skillIndexHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Cache-Control": "public, max-age=300, s-maxage=600",
-  "Content-Type": "application/json; charset=utf-8",
 }
 
 const app = new Hono<{ Bindings: Env }>()
@@ -96,7 +89,7 @@ app.all("/.well-known/agent-skills/index.json", async (c) => {
     return c.text("Method Not Allowed", 405, { Allow: "GET, HEAD" })
   }
 
-  const skill = await loadSkill(c)
+  const skill = await loadSkill(c.env.ASSETS, c.req.url)
 
   if (c.req.method === "HEAD") {
     return new Response(null, {
@@ -110,12 +103,12 @@ app.all("/.well-known/agent-skills/index.json", async (c) => {
   return c.json(index, 200, skillIndexHeaders)
 })
 
-app.all(`/.well-known/agent-skills/${skillName}/SKILL.md`, async (c) => {
+app.all(`/.well-known/agent-skills/${SKILL_NAME}/SKILL.md`, async (c) => {
   if (c.req.method !== "GET" && c.req.method !== "HEAD") {
     return c.text("Method Not Allowed", 405, { Allow: "GET, HEAD" })
   }
 
-  const skill = await loadSkill(c)
+  const skill = await loadSkill(c.env.ASSETS, c.req.url)
 
   if (c.req.method === "HEAD") {
     return new Response(null, {
@@ -569,130 +562,5 @@ If this issue persists, please report it to <info@sosumi.ai>.
     { "Content-Type": "text/markdown; charset=utf-8" },
   )
 })
-
-interface SkillArtifact {
-  bytes: ArrayBuffer
-  description: string
-  name: string
-}
-
-async function loadSkill(c: Context<{ Bindings: Env }>): Promise<SkillArtifact> {
-  const skillUrl = new URL("/SKILL.md", c.req.url)
-  const skillResponse = await c.env.ASSETS.fetch(new Request(skillUrl.toString()))
-
-  if (!skillResponse.ok) {
-    throw new HTTPException(500, {
-      message: "Failed to load SKILL.md",
-    })
-  }
-
-  const bytes = await skillResponse.arrayBuffer()
-  const frontmatter = parseSkillFrontmatter(new TextDecoder().decode(bytes))
-
-  assertValidSkillFrontmatter(frontmatter)
-
-  return {
-    bytes,
-    description: frontmatter.description,
-    name: frontmatter.name,
-  }
-}
-
-async function createSkillIndex(skill: SkillArtifact) {
-  return {
-    $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
-    skills: [
-      {
-        name: skill.name,
-        type: "skill-md",
-        description: skill.description,
-        url: `/.well-known/agent-skills/${skill.name}/SKILL.md`,
-        digest: `sha256:${await sha256Hex(skill.bytes)}`,
-        files: ["SKILL.md"],
-      },
-    ],
-  }
-}
-
-function parseSkillFrontmatter(markdown: string): Record<string, string> {
-  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)
-
-  if (!match) {
-    throw new HTTPException(500, {
-      message: "SKILL.md must start with YAML frontmatter.",
-    })
-  }
-
-  const fields: Record<string, string> = {}
-
-  for (const line of match[1].split(/\r?\n/)) {
-    if (!line.trim()) {
-      continue
-    }
-
-    const separator = line.indexOf(":")
-
-    if (separator === -1) {
-      throw new HTTPException(500, {
-        message: `Invalid SKILL.md frontmatter line: ${line}`,
-      })
-    }
-
-    const key = line.slice(0, separator).trim()
-    const value = line.slice(separator + 1).trim()
-
-    fields[key] = stripQuotes(value)
-  }
-
-  return fields
-}
-
-function stripQuotes(value: string): string {
-  if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    return value.slice(1, -1)
-  }
-
-  return value
-}
-
-function assertValidSkillFrontmatter(frontmatter: Record<string, string>) {
-  if (typeof frontmatter.name !== "string" || frontmatter.name.length === 0) {
-    throw new HTTPException(500, {
-      message: "Skill name is required.",
-    })
-  }
-
-  if (frontmatter.name !== skillName) {
-    throw new HTTPException(500, {
-      message: `Expected skill name "${skillName}", got "${frontmatter.name}".`,
-    })
-  }
-
-  if (!/^[a-z0-9](?:-?[a-z0-9])*$/.test(frontmatter.name) || frontmatter.name.length > 64) {
-    throw new HTTPException(500, {
-      message: `Invalid skill name: ${frontmatter.name}`,
-    })
-  }
-
-  if (typeof frontmatter.description !== "string" || frontmatter.description.length === 0) {
-    throw new HTTPException(500, {
-      message: "Skill description is required.",
-    })
-  }
-
-  if (frontmatter.description.length > 1024) {
-    throw new HTTPException(500, {
-      message: "Skill description must be 1024 characters or fewer.",
-    })
-  }
-}
-
-async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", bytes)
-  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("")
-}
 
 export default app

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
   createSkillIndex,
   loadSkill,
   SKILL_NAME,
+  skillExists,
   skillHeaders,
   skillIndexHeaders,
 } from "./lib/skill"
@@ -89,15 +90,17 @@ app.all("/.well-known/agent-skills/index.json", async (c) => {
     return c.text("Method Not Allowed", 405, { Allow: "GET, HEAD" })
   }
 
-  const skill = await loadSkill(c.env.ASSETS, c.req.url)
-
   if (c.req.method === "HEAD") {
+    if (!(await skillExists(c.env.ASSETS, c.req.url))) {
+      throw new HTTPException(500, { message: "Failed to load SKILL.md" })
+    }
     return new Response(null, {
       status: 200,
       headers: skillIndexHeaders,
     })
   }
 
+  const skill = await loadSkill(c.env.ASSETS, c.req.url)
   const index = await createSkillIndex(skill)
 
   return c.json(index, 200, skillIndexHeaders)
@@ -108,14 +111,17 @@ app.all(`/.well-known/agent-skills/${SKILL_NAME}/SKILL.md`, async (c) => {
     return c.text("Method Not Allowed", 405, { Allow: "GET, HEAD" })
   }
 
-  const skill = await loadSkill(c.env.ASSETS, c.req.url)
-
   if (c.req.method === "HEAD") {
+    if (!(await skillExists(c.env.ASSETS, c.req.url))) {
+      throw new HTTPException(500, { message: "Failed to load SKILL.md" })
+    }
     return new Response(null, {
       status: 200,
       headers: skillHeaders,
     })
   }
+
+  const skill = await loadSkill(c.env.ASSETS, c.req.url)
 
   return new Response(skill.bytes, {
     status: 200,

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,14 +75,31 @@ app.use("*", async (c, next) => {
   await next()
 })
 
-app.all("/mcp", async (c) => {
-  const mcpServer = createMcpServer({
-    EXTERNAL_DOC_HOST_ALLOWLIST: c.env.EXTERNAL_DOC_HOST_ALLOWLIST,
-    EXTERNAL_DOC_HOST_BLOCKLIST: c.env.EXTERNAL_DOC_HOST_BLOCKLIST,
+app.get("/", async (c) => {
+  const accepted = accepts(c, {
+    header: "Accept",
+    supports: ["text/markdown", "text/html"],
+    default: "text/html",
   })
-  const transport = new StreamableHTTPTransport()
-  await mcpServer.connect(transport)
-  return transport.handleRequest(c)
+
+  if (accepted === "text/markdown") {
+    const llmsUrl = new URL("/llms.txt", c.req.url)
+    const llmsResponse = await c.env.ASSETS.fetch(new Request(llmsUrl.toString()))
+
+    if (!llmsResponse.ok) {
+      throw new HTTPException(500, {
+        message: "Failed to load llms.txt",
+      })
+    }
+
+    const markdown = await llmsResponse.text()
+    return c.text(markdown, 200, {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=300, s-maxage=600",
+    })
+  }
+
+  return c.env.ASSETS.fetch(c.req.raw)
 })
 
 app.all("/.well-known/agent-skills/index.json", async (c) => {
@@ -129,34 +146,17 @@ app.all(`/.well-known/agent-skills/${SKILL_NAME}/SKILL.md`, async (c) => {
   })
 })
 
-app.get("/", async (c) => {
-  const accepted = accepts(c, {
-    header: "Accept",
-    supports: ["text/markdown", "text/html"],
-    default: "text/html",
-  })
-
-  if (accepted === "text/markdown") {
-    const llmsUrl = new URL("/llms.txt", c.req.url)
-    const llmsResponse = await c.env.ASSETS.fetch(new Request(llmsUrl.toString()))
-
-    if (!llmsResponse.ok) {
-      throw new HTTPException(500, {
-        message: "Failed to load llms.txt",
-      })
-    }
-
-    const markdown = await llmsResponse.text()
-    return c.text(markdown, 200, {
-      "Content-Type": "text/markdown; charset=utf-8",
-      "Cache-Control": "public, max-age=300, s-maxage=600",
-    })
-  }
-
-  return c.env.ASSETS.fetch(c.req.raw)
-})
-
 app.get("/bot", (c) => c.redirect("/#bot", 302))
+
+app.all("/mcp", async (c) => {
+  const mcpServer = createMcpServer({
+    EXTERNAL_DOC_HOST_ALLOWLIST: c.env.EXTERNAL_DOC_HOST_ALLOWLIST,
+    EXTERNAL_DOC_HOST_BLOCKLIST: c.env.EXTERNAL_DOC_HOST_BLOCKLIST,
+  })
+  const transport = new StreamableHTTPTransport()
+  await mcpServer.connect(transport)
+  return transport.handleRequest(c)
+})
 
 app.get("/search", async (c) => {
   const query = c.req.query("q")?.trim() ?? ""

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,15 +96,16 @@ app.all("/.well-known/agent-skills/index.json", async (c) => {
     return c.text("Method Not Allowed", 405, { Allow: "GET, HEAD" })
   }
 
-  const skill = await loadSkill(c)
-  const index = await createSkillIndex(skill)
-
   if (c.req.method === "HEAD") {
+    await assertSkillAssetExists(c)
     return new Response(null, {
       status: 200,
       headers: skillIndexHeaders,
     })
   }
+
+  const skill = await loadSkill(c)
+  const index = await createSkillIndex(skill)
 
   return c.json(index, 200, skillIndexHeaders)
 })
@@ -114,14 +115,15 @@ app.all("/.well-known/agent-skills/sosumi/SKILL.md", async (c) => {
     return c.text("Method Not Allowed", 405, { Allow: "GET, HEAD" })
   }
 
-  const skill = await loadSkill(c)
-
   if (c.req.method === "HEAD") {
+    await assertSkillAssetExists(c)
     return new Response(null, {
       status: 200,
       headers: skillHeaders,
     })
   }
+
+  const skill = await loadSkill(c)
 
   return new Response(skill.bytes, {
     status: 200,
@@ -575,6 +577,19 @@ interface SkillArtifact {
   name: string
 }
 
+async function assertSkillAssetExists(c: Context<{ Bindings: Env }>): Promise<void> {
+  const skillUrl = new URL("/SKILL.md", c.req.url)
+  const headResponse = await c.env.ASSETS.fetch(
+    new Request(skillUrl.toString(), { method: "HEAD" }),
+  )
+
+  if (!headResponse.ok) {
+    throw new HTTPException(500, {
+      message: "Failed to load SKILL.md",
+    })
+  }
+}
+
 async function loadSkill(c: Context<{ Bindings: Env }>): Promise<SkillArtifact> {
   const skillUrl = new URL("/SKILL.md", c.req.url)
   const skillResponse = await c.env.ASSETS.fetch(new Request(skillUrl.toString()))
@@ -614,7 +629,7 @@ async function createSkillIndex(skill: SkillArtifact) {
 }
 
 function parseSkillFrontmatter(markdown: string): Record<string, string> {
-  const match = markdown.match(/^---\n([\s\S]*?)\n---\n/)
+  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)
 
   if (!match) {
     throw new HTTPException(500, {
@@ -624,7 +639,7 @@ function parseSkillFrontmatter(markdown: string): Record<string, string> {
 
   const fields: Record<string, string> = {}
 
-  for (const line of match[1].split("\n")) {
+  for (const line of match[1].split(/\r?\n/)) {
     if (!line.trim()) {
       continue
     }
@@ -658,9 +673,15 @@ function stripQuotes(value: string): string {
 }
 
 function assertValidSkillFrontmatter(frontmatter: Record<string, string>) {
+  if (typeof frontmatter.name !== "string" || frontmatter.name.length === 0) {
+    throw new HTTPException(500, {
+      message: "Skill name is required.",
+    })
+  }
+
   if (frontmatter.name !== skillName) {
     throw new HTTPException(500, {
-      message: `Expected skill name "${skillName}", got "${frontmatter.name ?? ""}".`,
+      message: `Expected skill name "${skillName}", got "${frontmatter.name}".`,
     })
   }
 
@@ -670,7 +691,7 @@ function assertValidSkillFrontmatter(frontmatter: Record<string, string>) {
     })
   }
 
-  if (frontmatter.description.length === 0) {
+  if (typeof frontmatter.description !== "string" || frontmatter.description.length === 0) {
     throw new HTTPException(500, {
       message: "Skill description is required.",
     })

--- a/src/lib/skill.ts
+++ b/src/lib/skill.ts
@@ -1,0 +1,140 @@
+import { HTTPException } from "hono/http-exception"
+
+export const SKILL_NAME = "sosumi"
+
+export const skillHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Cache-Control": "public, max-age=300, s-maxage=600",
+  "Content-Type": "text/markdown; charset=utf-8",
+}
+
+export const skillIndexHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Cache-Control": "public, max-age=300, s-maxage=600",
+  "Content-Type": "application/json; charset=utf-8",
+}
+
+export interface SkillArtifact {
+  bytes: ArrayBuffer
+  description: string
+  name: string
+}
+
+export async function loadSkill(assets: Fetcher, baseUrl: string): Promise<SkillArtifact> {
+  const skillUrl = new URL("/SKILL.md", baseUrl)
+  const skillResponse = await assets.fetch(new Request(skillUrl.toString()))
+
+  if (!skillResponse.ok) {
+    throw new HTTPException(500, {
+      message: "Failed to load SKILL.md",
+    })
+  }
+
+  const bytes = await skillResponse.arrayBuffer()
+  const frontmatter = parseSkillFrontmatter(new TextDecoder().decode(bytes))
+
+  assertValidSkillFrontmatter(frontmatter)
+
+  return {
+    bytes,
+    description: frontmatter.description,
+    name: frontmatter.name,
+  }
+}
+
+export async function createSkillIndex(skill: SkillArtifact) {
+  return {
+    $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+    skills: [
+      {
+        name: skill.name,
+        type: "skill-md",
+        description: skill.description,
+        url: `/.well-known/agent-skills/${skill.name}/SKILL.md`,
+        digest: `sha256:${await sha256Hex(skill.bytes)}`,
+        files: ["SKILL.md"],
+      },
+    ],
+  }
+}
+
+function parseSkillFrontmatter(markdown: string): Record<string, string> {
+  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)
+
+  if (!match) {
+    throw new HTTPException(500, {
+      message: "SKILL.md must start with YAML frontmatter.",
+    })
+  }
+
+  const fields: Record<string, string> = {}
+
+  for (const line of match[1].split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue
+    }
+
+    const separator = line.indexOf(":")
+
+    if (separator === -1) {
+      throw new HTTPException(500, {
+        message: `Invalid SKILL.md frontmatter line: ${line}`,
+      })
+    }
+
+    const key = line.slice(0, separator).trim()
+    const value = line.slice(separator + 1).trim()
+
+    fields[key] = stripQuotes(value)
+  }
+
+  return fields
+}
+
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1)
+  }
+
+  return value
+}
+
+function assertValidSkillFrontmatter(frontmatter: Record<string, string>) {
+  if (typeof frontmatter.name !== "string" || frontmatter.name.length === 0) {
+    throw new HTTPException(500, {
+      message: "Skill name is required.",
+    })
+  }
+
+  if (frontmatter.name !== SKILL_NAME) {
+    throw new HTTPException(500, {
+      message: `Expected skill name "${SKILL_NAME}", got "${frontmatter.name}".`,
+    })
+  }
+
+  if (!/^[a-z0-9](?:-?[a-z0-9])*$/.test(frontmatter.name) || frontmatter.name.length > 64) {
+    throw new HTTPException(500, {
+      message: `Invalid skill name: ${frontmatter.name}`,
+    })
+  }
+
+  if (typeof frontmatter.description !== "string" || frontmatter.description.length === 0) {
+    throw new HTTPException(500, {
+      message: "Skill description is required.",
+    })
+  }
+
+  if (frontmatter.description.length > 1024) {
+    throw new HTTPException(500, {
+      message: "Skill description must be 1024 characters or fewer.",
+    })
+  }
+}
+
+async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("")
+}

--- a/src/lib/skill.ts
+++ b/src/lib/skill.ts
@@ -21,8 +21,7 @@ export interface SkillArtifact {
 }
 
 export async function loadSkill(assets: Fetcher, baseUrl: string): Promise<SkillArtifact> {
-  const skillUrl = new URL("/SKILL.md", baseUrl)
-  const skillResponse = await assets.fetch(new Request(skillUrl.toString()))
+  const skillResponse = await assets.fetch(new Request(skillAssetUrl(baseUrl)))
 
   if (!skillResponse.ok) {
     throw new HTTPException(500, {
@@ -40,6 +39,15 @@ export async function loadSkill(assets: Fetcher, baseUrl: string): Promise<Skill
     description: frontmatter.description,
     name: frontmatter.name,
   }
+}
+
+export async function skillExists(assets: Fetcher, baseUrl: string): Promise<boolean> {
+  const response = await assets.fetch(new Request(skillAssetUrl(baseUrl), { method: "HEAD" }))
+  return response.ok
+}
+
+function skillAssetUrl(baseUrl: string): string {
+  return new URL("/SKILL.md", baseUrl).toString()
 }
 
 export async function createSkillIndex(skill: SkillArtifact) {

--- a/tests/agent-skills.test.ts
+++ b/tests/agent-skills.test.ts
@@ -1,0 +1,91 @@
+import { SELF } from "cloudflare:test"
+import { describe, expect, it } from "vitest"
+
+describe("Agent Skills discovery", () => {
+  const indexUrl = "https://sosumi.ai/.well-known/agent-skills/index.json"
+  const skillUrl = "https://sosumi.ai/.well-known/agent-skills/sosumi/SKILL.md"
+
+  it("serves a v0.2.0 discovery index", async () => {
+    const response = await SELF.fetch(indexUrl)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*")
+    expect(response.headers.get("Content-Type")).toContain("application/json")
+
+    const index = await response.json<{
+      $schema: string
+      skills: Array<{
+        name: string
+        type: string
+        description: string
+        url: string
+        digest: string
+        files: string[]
+      }>
+    }>()
+
+    expect(index.$schema).toBe("https://schemas.agentskills.io/discovery/0.2.0/schema.json")
+    expect(index.skills).toHaveLength(1)
+    expect(index.skills[0]).toMatchObject({
+      name: "sosumi",
+      type: "skill-md",
+      description:
+        "Fetches Apple documentation as Markdown via Sosumi. Use for Apple API reference, Human Interface Guidelines, WWDC transcripts, and external Swift-DocC pages.",
+      url: "/.well-known/agent-skills/sosumi/SKILL.md",
+      files: ["SKILL.md"],
+    })
+    expect(index.skills[0].digest).toMatch(/^sha256:[a-f0-9]{64}$/)
+  })
+
+  it("serves the canonical SKILL.md artifact", async () => {
+    const response = await SELF.fetch(skillUrl)
+    const markdown = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*")
+    expect(response.headers.get("Content-Type")).toContain("text/markdown")
+    expect(markdown).toContain("name: sosumi")
+    expect(markdown).toContain("# Sosumi Skill")
+  })
+
+  it("indexes the digest for the served SKILL.md bytes", async () => {
+    const [indexResponse, skillResponse] = await Promise.all([
+      SELF.fetch(indexUrl),
+      SELF.fetch(skillUrl),
+    ])
+
+    const index = await indexResponse.json<{ skills: Array<{ digest: string }> }>()
+    const skillBytes = await skillResponse.arrayBuffer()
+    const digest = await crypto.subtle.digest("SHA-256", skillBytes)
+    const hexDigest = [...new Uint8Array(digest)]
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("")
+
+    expect(index.skills[0].digest).toBe(`sha256:${hexDigest}`)
+  })
+
+  it("supports HEAD requests", async () => {
+    const [indexResponse, skillResponse] = await Promise.all([
+      SELF.fetch(indexUrl, { method: "HEAD" }),
+      SELF.fetch(skillUrl, { method: "HEAD" }),
+    ])
+
+    expect(indexResponse.status).toBe(200)
+    expect(indexResponse.headers.get("Content-Type")).toContain("application/json")
+    expect(await indexResponse.text()).toBe("")
+
+    expect(skillResponse.status).toBe(200)
+    expect(skillResponse.headers.get("Content-Type")).toContain("text/markdown")
+    expect(await skillResponse.text()).toBe("")
+  })
+
+  it("returns 404 for missing discovery artifacts", async () => {
+    const [missingSkillResponse, missingFileResponse] = await Promise.all([
+      SELF.fetch("https://sosumi.ai/.well-known/agent-skills/missing/SKILL.md"),
+      SELF.fetch("https://sosumi.ai/.well-known/agent-skills/sosumi/NOPE.md"),
+    ])
+
+    expect(missingSkillResponse.status).toBe(404)
+    expect(missingFileResponse.status).toBe(404)
+  })
+})

--- a/tests/agent-skills.test.ts
+++ b/tests/agent-skills.test.ts
@@ -12,7 +12,7 @@ describe("Agent Skills discovery", () => {
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*")
     expect(response.headers.get("Content-Type")).toContain("application/json")
 
-    const index = await response.json<{
+    const index = (await response.json()) as {
       $schema: string
       skills: Array<{
         name: string
@@ -22,7 +22,7 @@ describe("Agent Skills discovery", () => {
         digest: string
         files: string[]
       }>
-    }>()
+    }
 
     expect(index.$schema).toBe("https://schemas.agentskills.io/discovery/0.2.0/schema.json")
     expect(index.skills).toHaveLength(1)
@@ -54,7 +54,7 @@ describe("Agent Skills discovery", () => {
       SELF.fetch(skillUrl),
     ])
 
-    const index = await indexResponse.json<{ skills: Array<{ digest: string }> }>()
+    const index = (await indexResponse.json()) as { skills: Array<{ digest: string }> }
     const skillBytes = await skillResponse.arrayBuffer()
     const digest = await crypto.subtle.digest("SHA-256", skillBytes)
     const hexDigest = [...new Uint8Array(digest)]

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,7 @@
   "assets": {
     "binding": "ASSETS",
     "directory": "./public",
-    "run_worker_first": ["/"]
+    "run_worker_first": ["/", "/.well-known/agent-skills/*"]
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
- Add Hono-backed Agent Skills discovery routes for Sosumi at `/.well-known/agent-skills/*`
- Generate the discovery index from canonical `public/SKILL.md` at request time, including digest verification data
- Document `npx skills add https://sosumi.ai` in the site, README, and `llms.txt`
