### PR TITLE
Update package metadata to enable npm trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@nshipster/sosumi",
   "version": "1.0.3",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/NSHipster/sosumi.ai"
+  },
   "type": "module",
   "engines": {
     "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,27 @@
 {
   "name": "@nshipster/sosumi",
   "version": "1.0.3",
+  "description": "Making Apple docs AI-readable",
   "license": "MIT",
+  "author": "NSHipster",
   "repository": {
     "type": "git",
     "url": "https://github.com/NSHipster/sosumi.ai"
+  },
+  "keywords": [
+    "apple",
+    "docs",
+    "documentation",
+    "mcp",
+    "cli",
+    "markdown",
+    "swift-docc",
+    "ai"
+  ],
+  "preferGlobal": true,
+  "homepage": "https://sosumi.ai",
+  "bugs": {
+    "url": "https://github.com/NSHipster/sosumi.ai/issues"
   },
   "type": "module",
   "engines": {


### PR DESCRIPTION
`package.json` was missing repository information. Also added other useful metadata while we're here.