### PR TITLE
Surface deprecated API warnings from DocC JSON in Markdown output

### DIFF
--- a/src/lib/reference/render.ts
+++ b/src/lib/reference/render.ts
@@ -7,6 +7,7 @@ import type {
   ContentItem,
   Declaration,
   IndexContentItem,
+  Platform,
   PossibleValueItem,
   PropertyItem,
   TopicSection,
@@ -66,6 +67,8 @@ export async function renderFromJSON(
       markdown += `> ${abstractText}\n\n`
     }
   }
+
+  markdown += renderDeprecationNotice(jsonData, jsonData.references, options.externalOrigin)
 
   // Add declaration
   if (jsonData.primaryContentSections) {
@@ -192,6 +195,10 @@ function generateFrontMatterFromJSON(jsonData: AppleDocJSON, sourceUrl: string):
 
   frontMatter.source = sourceUrl
   frontMatter.timestamp = new Date().toISOString()
+
+  if (isSymbolDeprecated(jsonData)) {
+    frontMatter.deprecated = "true"
+  }
 
   // Convert to YAML format
   const yamlLines = Object.entries(frontMatter).map(([key, value]) => `${key}: ${value}`)
@@ -452,7 +459,8 @@ function renderContentArray(
         ? renderContentArray(item.content, references, depth + 1, externalOrigin)
         : ""
       const cleanContent = asideContent.trim().replace(/\n/g, "\n> ")
-      markdown += `> [!${calloutType}]\n> ${cleanContent}\n\n`
+      const deprecatedLabel = style.toLowerCase() === "deprecated" ? "**Deprecated**\n>\n> " : ""
+      markdown += `> [!${calloutType}]\n> ${deprecatedLabel}${cleanContent}\n\n`
     } else if (item.type === "table") {
       markdown += renderTable(item, references, depth, externalOrigin)
     } else if (item.type === "tabNavigator" && item.tabs?.length) {
@@ -625,7 +633,8 @@ function renderTopicSections(
                 ? reference.abstract.map((a: { text: string }) => a.text).join("")
                 : ""
 
-            markdown += `- [${title}](${url})`
+            const deprecatedLabel = reference?.deprecated ? " *(Deprecated)*" : ""
+            markdown += `- [${title}](${url})${deprecatedLabel}`
             if (abstract) {
               markdown += ` ${abstract}`
             }
@@ -723,6 +732,88 @@ function renderSeeAlso(
   }
 
   return markdown
+}
+
+/**
+ * Whether the symbol page represents a deprecated API.
+ */
+function isSymbolDeprecated(jsonData: AppleDocJSON): boolean {
+  if (jsonData.deprecationSummary?.length) {
+    return true
+  }
+
+  const identifier = jsonData.identifier?.url
+  if (identifier && jsonData.references?.[identifier]?.deprecated === true) {
+    return true
+  }
+
+  const platforms = jsonData.metadata?.platforms
+  if (platforms?.some((platform) => platform.deprecated === true || platform.deprecatedAt)) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Collect a deprecation message from platform availability metadata.
+ */
+function getDeprecationMessageFromPlatforms(platforms?: Platform[]): string | null {
+  if (!platforms?.length) {
+    return null
+  }
+
+  const deprecatedPlatforms = platforms.filter(
+    (platform) => platform.deprecated === true || platform.deprecatedAt,
+  )
+  if (deprecatedPlatforms.length === 0) {
+    return null
+  }
+
+  const uniqueMessages = [
+    ...new Set(
+      deprecatedPlatforms
+        .map((platform) => platform.message?.trim())
+        .filter((message): message is string => Boolean(message)),
+    ),
+  ]
+
+  if (uniqueMessages.length === 1) {
+    return uniqueMessages[0]
+  }
+
+  if (uniqueMessages.length > 1) {
+    return deprecatedPlatforms
+      .filter((platform) => platform.message)
+      .map((platform) => `**${platform.name}:** ${platform.message}`)
+      .join("\n")
+  }
+
+  return "This symbol is deprecated."
+}
+
+/**
+ * Render a deprecation callout for deprecated symbol pages.
+ */
+function renderDeprecationNotice(
+  jsonData: AppleDocJSON,
+  references?: Record<string, ContentItem>,
+  externalOrigin?: string,
+): string {
+  let body = ""
+
+  if (jsonData.deprecationSummary?.length) {
+    body = renderContentArray(jsonData.deprecationSummary, references, 0, externalOrigin).trim()
+  } else {
+    body = getDeprecationMessageFromPlatforms(jsonData.metadata?.platforms) ?? ""
+  }
+
+  if (!body) {
+    return ""
+  }
+
+  const quotedBody = body.replace(/\n/g, "\n> ")
+  return `> [!WARNING]\n> **Deprecated**\n>\n> ${quotedBody}\n\n`
 }
 
 /**

--- a/src/lib/reference/render.ts
+++ b/src/lib/reference/render.ts
@@ -738,21 +738,7 @@ function renderSeeAlso(
  * Whether the symbol page represents a deprecated API.
  */
 function isSymbolDeprecated(jsonData: AppleDocJSON): boolean {
-  if (jsonData.deprecationSummary?.length) {
-    return true
-  }
-
-  const identifier = jsonData.identifier?.url
-  if (identifier && jsonData.references?.[identifier]?.deprecated === true) {
-    return true
-  }
-
-  const platforms = jsonData.metadata?.platforms
-  if (platforms?.some((platform) => platform.deprecated === true || platform.deprecatedAt)) {
-    return true
-  }
-
-  return false
+  return getDeprecationNoticeBody(jsonData, jsonData.references) !== null
 }
 
 /**
@@ -789,7 +775,42 @@ function getDeprecationMessageFromPlatforms(platforms?: Platform[]): string | nu
       .join("\n")
   }
 
-  return "This symbol is deprecated."
+  return DEFAULT_DEPRECATION_MESSAGE
+}
+
+const DEFAULT_DEPRECATION_MESSAGE = "This symbol is deprecated."
+
+/**
+ * Resolve deprecation notice text from DocC JSON (without rendering the callout).
+ */
+function getDeprecationNoticeBody(
+  jsonData: AppleDocJSON,
+  references?: Record<string, ContentItem>,
+  externalOrigin?: string,
+): string | null {
+  if (jsonData.deprecationSummary?.length) {
+    const summary = renderContentArray(
+      jsonData.deprecationSummary,
+      references,
+      0,
+      externalOrigin,
+    ).trim()
+    if (summary) {
+      return summary
+    }
+  }
+
+  const platformMessage = getDeprecationMessageFromPlatforms(jsonData.metadata?.platforms)
+  if (platformMessage) {
+    return platformMessage
+  }
+
+  const identifier = jsonData.identifier?.url
+  if (identifier && references?.[identifier]?.deprecated === true) {
+    return DEFAULT_DEPRECATION_MESSAGE
+  }
+
+  return null
 }
 
 /**
@@ -800,14 +821,7 @@ function renderDeprecationNotice(
   references?: Record<string, ContentItem>,
   externalOrigin?: string,
 ): string {
-  let body = ""
-
-  if (jsonData.deprecationSummary?.length) {
-    body = renderContentArray(jsonData.deprecationSummary, references, 0, externalOrigin).trim()
-  } else {
-    body = getDeprecationMessageFromPlatforms(jsonData.metadata?.platforms) ?? ""
-  }
-
+  const body = getDeprecationNoticeBody(jsonData, references, externalOrigin)
   if (!body) {
     return ""
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,6 +75,9 @@ export interface ContentItem {
 
   // Abstract content
   abstract?: TextFragment[]
+
+  /** Present on reference entries for deprecated symbols. */
+  deprecated?: boolean
 }
 
 // ============================================================================
@@ -261,6 +264,10 @@ export interface Platform {
   name: string
   introducedAt: string
   beta?: boolean
+  deprecated?: boolean
+  deprecatedAt?: string
+  message?: string
+  unavailable?: boolean
 }
 
 /**
@@ -297,6 +304,8 @@ export interface AppleDocJSON {
 
   // Content
   abstract?: Array<{ text: string; type: string }>
+  /** DocC deprecation notice shown at the top of deprecated symbol pages. */
+  deprecationSummary?: ContentItem[]
   sections?: ContentItem[]
 
   // Primary content sections

--- a/tests/fixtures/reference/nsdata-getbytes.json
+++ b/tests/fixtures/reference/nsdata-getbytes.json
@@ -1,0 +1,414 @@
+{
+  "metadata": {
+    "externalID": "c:objc(cs)NSData(im)getBytes:",
+    "roleHeading": "Instance Method",
+    "role": "symbol",
+    "modules": [
+      {
+        "name": "Foundation"
+      }
+    ],
+    "title": "getBytes(_:)",
+    "platforms": [
+      {
+        "unavailable": false,
+        "name": "iOS",
+        "beta": false,
+        "deprecated": false,
+        "deprecatedAt": "8.0",
+        "message": "This method is unsafe because it could potentially cause buffer overruns. Use -getBytes:length: instead.",
+        "introducedAt": "2.0"
+      },
+      {
+        "name": "iPadOS",
+        "beta": false,
+        "deprecated": false,
+        "unavailable": false,
+        "message": "This method is unsafe because it could potentially cause buffer overruns. Use -getBytes:length: instead.",
+        "introducedAt": "2.0",
+        "deprecatedAt": "8.0"
+      },
+      {
+        "beta": false,
+        "message": "This method is unsafe because it could potentially cause buffer overruns. Use -getBytes:length: instead.",
+        "introducedAt": "13.1",
+        "unavailable": false,
+        "deprecated": false,
+        "name": "Mac Catalyst",
+        "deprecatedAt": "13.1"
+      },
+      {
+        "beta": false,
+        "deprecatedAt": "10.10",
+        "introducedAt": "10.0",
+        "name": "macOS",
+        "unavailable": false,
+        "deprecated": false,
+        "message": "This method is unsafe because it could potentially cause buffer overruns. Use -getBytes:length: instead."
+      },
+      {
+        "deprecatedAt": "9.0",
+        "beta": false,
+        "name": "tvOS",
+        "unavailable": false,
+        "introducedAt": "9.0",
+        "message": "This method is unsafe because it could potentially cause buffer overruns. Use -getBytes:length: instead.",
+        "deprecated": false
+      },
+      {
+        "name": "visionOS",
+        "deprecatedAt": "1.0",
+        "unavailable": false,
+        "deprecated": false,
+        "message": "This method is unsafe because it could potentially cause buffer overruns. Use -getBytes:length: instead.",
+        "beta": false,
+        "introducedAt": "1.0"
+      },
+      {
+        "message": "This method is unsafe because it could potentially cause buffer overruns. Use -getBytes:length: instead.",
+        "deprecatedAt": "2.0",
+        "introducedAt": "2.0",
+        "deprecated": false,
+        "unavailable": false,
+        "name": "watchOS",
+        "beta": false
+      }
+    ],
+    "extendedModule": "Foundation",
+    "fragments": [
+      {
+        "text": "func",
+        "kind": "keyword"
+      },
+      {
+        "text": " ",
+        "kind": "text"
+      },
+      {
+        "kind": "identifier",
+        "text": "getBytes"
+      },
+      {
+        "kind": "text",
+        "text": "("
+      },
+      {
+        "preciseIdentifier": "s:Sv",
+        "kind": "typeIdentifier",
+        "text": "UnsafeMutableRawPointer"
+      },
+      {
+        "kind": "text",
+        "text": ")"
+      }
+    ],
+    "navigatorTitle": [
+      {
+        "text": "- ",
+        "kind": "text"
+      },
+      {
+        "kind": "identifier",
+        "text": "getBytes:"
+      }
+    ],
+    "symbolKind": "method"
+  },
+  "abstract": [
+    {
+      "text": "Copies a data object\u2019s contents into a given buffer.",
+      "type": "text"
+    }
+  ],
+  "deprecationSummary": [
+    {
+      "inlineContent": [
+        {
+          "type": "text",
+          "text": "This method is unsafe because it could potentially cause buffer overruns. Use "
+        },
+        {
+          "type": "reference",
+          "identifier": "doc://com.apple.foundation/documentation/Foundation/NSData/getBytes(_:length:)",
+          "isActive": true
+        },
+        {
+          "text": " or ",
+          "type": "text"
+        },
+        {
+          "identifier": "doc://com.apple.foundation/documentation/Foundation/NSData/getBytes(_:range:)",
+          "isActive": true,
+          "type": "reference"
+        },
+        {
+          "type": "text",
+          "text": " instead."
+        }
+      ],
+      "type": "paragraph"
+    }
+  ],
+  "identifier": {
+    "interfaceLanguage": "swift",
+    "url": "doc://com.apple.foundation/documentation/Foundation/NSData/getBytes(_:)"
+  },
+  "references": {
+    "doc://com.apple.foundation/documentation/Foundation": {
+      "abstract": [
+        {
+          "text": "Access essential data types, collections, and operating-system services to define the base layer of functionality for your app.",
+          "type": "text"
+        }
+      ],
+      "role": "collection",
+      "url": "/documentation/foundation",
+      "type": "topic",
+      "title": "Foundation",
+      "identifier": "doc://com.apple.foundation/documentation/Foundation",
+      "kind": "symbol"
+    },
+    "doc://com.apple.foundation/documentation/Foundation/NSData/getBytes(_:)": {
+      "identifier": "doc://com.apple.foundation/documentation/Foundation/NSData/getBytes(_:)",
+      "kind": "symbol",
+      "title": "getBytes(_:)",
+      "fragments": [
+        {
+          "kind": "keyword",
+          "text": "func"
+        },
+        {
+          "kind": "text",
+          "text": " "
+        },
+        {
+          "text": "getBytes",
+          "kind": "identifier"
+        },
+        {
+          "text": "(",
+          "kind": "text"
+        },
+        {
+          "text": "UnsafeMutableRawPointer",
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "s:Sv"
+        },
+        {
+          "text": ")",
+          "kind": "text"
+        }
+      ],
+      "type": "topic",
+      "abstract": [
+        {
+          "type": "text",
+          "text": "Copies a data object\u2019s contents into a given buffer."
+        }
+      ],
+      "navigatorTitle": [
+        {
+          "kind": "text",
+          "text": "- "
+        },
+        {
+          "kind": "identifier",
+          "text": "getBytes:"
+        }
+      ],
+      "url": "/documentation/foundation/nsdata/getbytes(_:)",
+      "deprecated": true,
+      "role": "symbol"
+    },
+    "doc://com.apple.foundation/documentation/Foundation/NSData/getBytes(_:length:)": {
+      "type": "topic",
+      "fragments": [
+        {
+          "kind": "keyword",
+          "text": "func"
+        },
+        {
+          "kind": "text",
+          "text": " "
+        },
+        {
+          "kind": "identifier",
+          "text": "getBytes"
+        },
+        {
+          "text": "(",
+          "kind": "text"
+        },
+        {
+          "text": "UnsafeMutableRawPointer",
+          "preciseIdentifier": "s:Sv",
+          "kind": "typeIdentifier"
+        },
+        {
+          "text": ", ",
+          "kind": "text"
+        },
+        {
+          "kind": "externalParam",
+          "text": "length"
+        },
+        {
+          "kind": "text",
+          "text": ": "
+        },
+        {
+          "text": "Int",
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "s:Si"
+        },
+        {
+          "kind": "text",
+          "text": ")"
+        }
+      ],
+      "role": "symbol",
+      "navigatorTitle": [
+        {
+          "kind": "text",
+          "text": "- "
+        },
+        {
+          "kind": "identifier",
+          "text": "getBytes:length:"
+        }
+      ],
+      "url": "/documentation/foundation/nsdata/getbytes(_:length:)",
+      "abstract": [
+        {
+          "type": "text",
+          "text": "Copies a number of bytes from the start of the data object into a given buffer."
+        }
+      ],
+      "identifier": "doc://com.apple.foundation/documentation/Foundation/NSData/getBytes(_:length:)",
+      "title": "getBytes(_:length:)",
+      "kind": "symbol"
+    },
+    "doc://com.apple.foundation/documentation/Foundation/NSData/getBytes(_:range:)": {
+      "title": "getBytes(_:range:)",
+      "url": "/documentation/foundation/nsdata/getbytes(_:range:)",
+      "kind": "symbol",
+      "type": "topic",
+      "role": "symbol",
+      "navigatorTitle": [
+        {
+          "text": "- ",
+          "kind": "text"
+        },
+        {
+          "kind": "identifier",
+          "text": "getBytes:range:"
+        }
+      ],
+      "identifier": "doc://com.apple.foundation/documentation/Foundation/NSData/getBytes(_:range:)",
+      "fragments": [
+        {
+          "kind": "keyword",
+          "text": "func"
+        },
+        {
+          "text": " ",
+          "kind": "text"
+        },
+        {
+          "kind": "identifier",
+          "text": "getBytes"
+        },
+        {
+          "text": "(",
+          "kind": "text"
+        },
+        {
+          "kind": "typeIdentifier",
+          "text": "UnsafeMutableRawPointer",
+          "preciseIdentifier": "s:Sv"
+        },
+        {
+          "text": ", ",
+          "kind": "text"
+        },
+        {
+          "text": "range",
+          "kind": "externalParam"
+        },
+        {
+          "kind": "text",
+          "text": ": "
+        },
+        {
+          "kind": "typeIdentifier",
+          "text": "NSRange"
+        },
+        {
+          "text": ")",
+          "kind": "text"
+        }
+      ],
+      "abstract": [
+        {
+          "type": "text",
+          "text": "Copies a range of bytes from the data object into a given buffer."
+        }
+      ]
+    }
+  },
+  "primaryContentSections": [
+    {
+      "kind": "declarations",
+      "declarations": [
+        {
+          "tokens": [
+            {
+              "text": "func",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "text"
+            },
+            {
+              "text": "getBytes",
+              "kind": "identifier"
+            },
+            {
+              "kind": "text",
+              "text": "("
+            },
+            {
+              "text": "_",
+              "kind": "externalParam"
+            },
+            {
+              "kind": "text",
+              "text": " "
+            },
+            {
+              "text": "buffer",
+              "kind": "internalParam"
+            },
+            {
+              "kind": "text",
+              "text": ": "
+            },
+            {
+              "preciseIdentifier": "s:Sv",
+              "text": "UnsafeMutableRawPointer",
+              "identifier": "doc://com.externally.resolved.symbol/s:Sv",
+              "kind": "typeIdentifier"
+            },
+            {
+              "kind": "text",
+              "text": ")"
+            }
+          ],
+          "languages": ["swift"],
+          "platforms": ["iOS", "iPadOS", "Mac Catalyst", "macOS", "tvOS", "visionOS", "watchOS"]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -1,6 +1,7 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: pedantic type check */
 import { describe, expect, it } from "vitest"
 import { renderFromJSON } from "../src/lib/reference"
+import nsdataGetBytesFixture from "./fixtures/reference/nsdata-getbytes.json"
 import {
   circularReferenceData,
   deeplyNestedData,
@@ -61,6 +62,53 @@ describe("Render Function", () => {
         /^---\nsource: https:\/\/test\.com\ntimestamp: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\n---\n\n/,
       )
       expect(result).not.toContain("title:")
+    })
+
+    it("should mark deprecated symbols in front matter", async () => {
+      const result = await renderFromJSON(
+        nsdataGetBytesFixture as any,
+        "https://developer.apple.com/documentation/foundation/nsdata/getbytes(_:)",
+      )
+
+      expect(result).toContain("deprecated: true")
+    })
+  })
+
+  describe("Deprecation", () => {
+    it("should render deprecation summary from Apple DocC JSON", async () => {
+      const result = await renderFromJSON(
+        nsdataGetBytesFixture as any,
+        "https://developer.apple.com/documentation/foundation/nsdata/getbytes(_:)",
+      )
+
+      expect(result).toContain("> [!WARNING]")
+      expect(result).toContain("> **Deprecated**")
+      expect(result).toContain("buffer overruns")
+      expect(result).toContain(
+        "[getBytes(_:length:)](/documentation/foundation/nsdata/getbytes(_:length:)",
+      )
+    })
+
+    it("should render platform deprecation messages when deprecationSummary is absent", async () => {
+      const data = {
+        metadata: {
+          title: "legacyMethod()",
+          platforms: [
+            {
+              name: "iOS",
+              introducedAt: "2.0",
+              deprecatedAt: "8.0",
+              message: "Use modernMethod() instead.",
+            },
+          ],
+        },
+        abstract: [{ type: "text", text: "A legacy API." }],
+      }
+
+      const result = await renderFromJSON(data as any, "https://test.com")
+
+      expect(result).toContain("> **Deprecated**")
+      expect(result).toContain("Use modernMethod() instead.")
     })
   })
 
@@ -233,6 +281,9 @@ describe("Render Function", () => {
 
         const result = await renderFromJSON(data as any, "https://test.com")
         expect(result).toContain(`> ${test.expected}`)
+        if (test.style === "deprecated") {
+          expect(result).toContain("> **Deprecated**")
+        }
         expect(result).toContain(`> This is a ${test.style} aside.`)
       }
     })

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -110,6 +110,24 @@ describe("Render Function", () => {
       expect(result).toContain("> **Deprecated**")
       expect(result).toContain("Use modernMethod() instead.")
     })
+
+    it("should render a deprecation callout when only the self-reference is marked deprecated", async () => {
+      const symbolId = "doc://com.example/documentation/Example/legacy()"
+      const data = {
+        metadata: { title: "legacy()" },
+        identifier: { url: symbolId },
+        references: {
+          [symbolId]: { deprecated: true, title: "legacy()" },
+        },
+        abstract: [{ type: "text", text: "A legacy API." }],
+      }
+
+      const result = await renderFromJSON(data as any, "https://test.com")
+
+      expect(result).toContain("deprecated: true")
+      expect(result).toContain("> **Deprecated**")
+      expect(result).toContain("> This symbol is deprecated.")
+    })
   })
 
   describe("Breadcrumb Navigation", () => {


### PR DESCRIPTION
Fixes #73 

### Before

~~~markdown
---
title: getBytes(_:)
description: Copies a data object’s contents into a given buffer.
source: https://developer.apple.com/documentation/foundation/nsdata/getbytes(_:)
timestamp: 2026-05-31T13:56:56.012Z
---

**Navigation:** [Foundation](/documentation/foundation) › [nsdata](/documentation/foundation/nsdata)

**Instance Method**

# getBytes(_:)

**Available on:** iOS 2.0+, iPadOS 2.0+, Mac Catalyst 13.1+, macOS 10.0+, tvOS 9.0+, visionOS 1.0+, watchOS 2.0+

> Copies a data object’s contents into a given buffer.

```swift
func getBytes(_ buffer: UnsafeMutableRawPointer)
```
~~~

### After

The same page now includes deprecation from `deprecationSummary` and platform metadata:

~~~markdown
---
title: getBytes(_:)
description: Copies a data object’s contents into a given buffer.
source: https://developer.apple.com/documentation/foundation/nsdata/getbytes(_:)
timestamp: 2026-05-31T13:56:56.012Z
deprecated: true
---

**Navigation:** [Foundation](/documentation/foundation) › [nsdata](/documentation/foundation/nsdata)

**Instance Method**

# getBytes(_:)

**Available on:** iOS 2.0+, iPadOS 2.0+, Mac Catalyst 13.1+, macOS 10.0+, tvOS 9.0+, visionOS 1.0+, watchOS 2.0+

> Copies a data object’s contents into a given buffer.

> [!WARNING]
> **Deprecated**
>
> This method is unsafe because it could potentially cause buffer overruns. Use [getBytes(_:length:)](/documentation/foundation/nsdata/getbytes(_:length:)) or [getBytes(_:range:)](/documentation/foundation/nsdata/getbytes(_:range:)) instead.

```swift
func getBytes(_ buffer: UnsafeMutableRawPointer)
```
~~~
