### PR TITLE
Add agent discovery endpoints for MCP and API catalog

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 Allow: /
 Disallow: /documentation/
 Disallow: /external/

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import {
   renderHIGFromJSON,
   renderHIGTableOfContents,
 } from "./lib/hig"
-import { createMcpServer } from "./lib/mcp"
+import { createMcpServer, MCP_SERVER_INFO } from "./lib/mcp"
 import { fetchJSONData, renderFromJSON } from "./lib/reference"
 import { searchAppleDeveloperDocs } from "./lib/search"
 import {
@@ -58,6 +58,18 @@ app.use("*", async (c, next) => {
   // Development-specific headers
   if (c.env.NODE_ENV === "development") {
     c.header("Cache-Control", "no-store")
+  }
+
+  if (c.req.path === "/") {
+    c.header(
+      "Link",
+      [
+        '</.well-known/api-catalog>; rel="api-catalog"',
+        '</.well-known/mcp/server-card.json>; rel="service-desc"',
+        '</SKILL.md>; rel="service-doc"',
+        '</llms.txt>; rel="alternate"; type="text/markdown"',
+      ].join(", "),
+    )
   }
 })
 
@@ -144,6 +156,64 @@ app.all(`/.well-known/agent-skills/${SKILL_NAME}/SKILL.md`, async (c) => {
     status: 200,
     headers: skillHeaders,
   })
+})
+
+const discoveryHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Cache-Control": "public, max-age=300, s-maxage=600",
+} as const
+
+app.get("/.well-known/api-catalog", (c) => {
+  const origin = new URL(c.req.url).origin
+
+  return c.json(
+    {
+      linkset: [
+        {
+          anchor: `${origin}/mcp`,
+          "service-desc": [
+            {
+              href: `${origin}/.well-known/mcp/server-card.json`,
+              type: "application/json",
+            },
+          ],
+          "service-doc": [{ href: `${origin}/SKILL.md`, type: "text/markdown" }],
+          status: [{ href: `${origin}/` }],
+        },
+        {
+          anchor: `${origin}/documentation`,
+          "service-doc": [{ href: `${origin}/SKILL.md`, type: "text/markdown" }],
+        },
+      ],
+    },
+    200,
+    {
+      ...discoveryHeaders,
+      "Content-Type": "application/linkset+json; charset=utf-8",
+    },
+  )
+})
+
+app.get("/.well-known/mcp/server-card.json", (c) => {
+  const origin = new URL(c.req.url).origin
+
+  return c.json(
+    {
+      serverInfo: MCP_SERVER_INFO,
+      transport: {
+        type: "streamable-http",
+        endpoint: `${origin}/mcp`,
+      },
+      capabilities: {
+        tools: {},
+      },
+    },
+    200,
+    {
+      ...discoveryHeaders,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+  )
 })
 
 app.get("/bot", (c) => c.redirect("/#bot", 302))

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -9,11 +9,13 @@ import { searchAppleDeveloperDocs } from "./search"
 import { generateAppleDocUrl, normalizeDocumentationPath } from "./url"
 import { fetchVideoTranscriptMarkdown } from "./video"
 
+export const MCP_SERVER_INFO = {
+  name: "sosumi.ai",
+  version: "1.0.0",
+} as const
+
 export function createMcpServer(externalPolicyEnv: ExternalPolicyEnv = {}) {
-  const server = new McpServer({
-    name: "sosumi.ai",
-    version: "1.0.0",
-  })
+  const server = new McpServer(MCP_SERVER_INFO)
 
   // Register Apple search tool
   server.registerTool(

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -1,0 +1,50 @@
+import { SELF } from "cloudflare:test"
+import { describe, expect, it } from "vitest"
+
+describe("Agent discovery endpoints", () => {
+  it("serves an RFC 9727 API catalog", async () => {
+    const response = await SELF.fetch("https://sosumi.ai/.well-known/api-catalog")
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Content-Type")).toContain("application/linkset+json")
+
+    const catalog = (await response.json()) as {
+      linkset: Array<{ anchor: string; "service-desc"?: Array<{ href: string }> }>
+    }
+
+    expect(Array.isArray(catalog.linkset)).toBe(true)
+    expect(catalog.linkset.length).toBeGreaterThan(0)
+    expect(catalog.linkset[0].anchor).toMatch(/\/mcp$/)
+    expect(catalog.linkset[0]["service-desc"]?.[0].href).toContain(
+      "/.well-known/mcp/server-card.json",
+    )
+  })
+
+  it("serves an MCP server card", async () => {
+    const response = await SELF.fetch("https://sosumi.ai/.well-known/mcp/server-card.json")
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Content-Type")).toContain("application/json")
+
+    const card = (await response.json()) as {
+      serverInfo: { name: string; version: string }
+      transport: { type: string; endpoint: string }
+      capabilities: { tools: Record<string, never> }
+    }
+
+    expect(card.serverInfo.name).toBe("sosumi.ai")
+    expect(card.transport.endpoint).toMatch(/\/mcp$/)
+    expect(card.transport.type).toBe("streamable-http")
+    expect(card.capabilities.tools).toEqual({})
+  })
+
+  it("includes Link headers on the homepage", async () => {
+    const response = await SELF.fetch("https://sosumi.ai/")
+
+    expect(response.status).toBe(200)
+
+    const link = response.headers.get("Link")
+    expect(link).toContain('rel="api-catalog"')
+    expect(link).toContain("/.well-known/api-catalog")
+  })
+})


### PR DESCRIPTION
This PR makes sosumi.ai easier for agents to discover programmatically. It adds RFC 8288 Link headers on the homepage, Content Signals in robots.txt, an RFC 9727 API catalog at `/.well-known/api-catalog`, and an MCP Server Card at `/.well-known/mcp/server-card.json`. MCP server name and version are centralized in a shared constant so the live server and discovery metadata stay in sync.