### PR TITLE
Use reference title for inline links

### DIFF
--- a/src/lib/reference/render.ts
+++ b/src/lib/reference/render.ts
@@ -552,9 +552,11 @@ function renderInlineContent(
       } else if (item.type === "codeVoice") {
         return `\`${item.code}\``
       } else if (item.type === "reference") {
+        const reference = item.identifier ? references?.[item.identifier] : undefined
         const title =
           item.title ||
           item.text ||
+          reference?.title ||
           (item.identifier ? extractTitleFromIdentifier(item.identifier) : "")
         const url = item.identifier
           ? convertIdentifierToURL(item.identifier, references, externalOrigin)

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -1008,6 +1008,39 @@ describe("Render Function", () => {
       const result = await renderFromJSON(data as any, "https://test.com")
       expect(result).toContain("[Unknown Reference](unknown://identifier/format)")
     })
+
+    it("should use the reference title for inline links without an inline title", async () => {
+      const url = "https://github.com/apple/foundation-models-utilities"
+      const data = {
+        metadata: { title: "Workaround Test" },
+        primaryContentSections: [
+          {
+            kind: "content",
+            content: [
+              {
+                type: "paragraph",
+                inlineContent: [
+                  { type: "text", text: "Import the " },
+                  { type: "reference", identifier: url },
+                  { type: "text", text: " package." },
+                ],
+              },
+            ],
+          },
+        ],
+        references: {
+          [url]: {
+            type: "link",
+            title: "Foundation Models framework utilities",
+            url,
+          },
+        },
+      }
+
+      const result = await renderFromJSON(data as any, "https://test.com")
+      expect(result).toContain(`[Foundation Models framework utilities](${url})`)
+      expect(result).not.toContain("[foundation-models]")
+    })
   })
 
   describe("Title Extraction from Identifiers", () => {


### PR DESCRIPTION
Fixes #79 

Inline reference links looked up their text only from the inline item, then fell back to deriving a title from the identifier. For external links, that fallback stripped a trailing hyphenated segment as a disambiguation suffix, so a link to foundation-models-utilities rendered as "foundation-models".