### PR TITLE
Render topic sections that have no title

### DIFF
--- a/src/lib/reference/render.ts
+++ b/src/lib/reference/render.ts
@@ -621,34 +621,34 @@ function renderTopicSections(
   for (const topic of topics) {
     if (topic.title) {
       markdown += `## ${topic.title}\n\n`
+    }
 
-      if (topic.identifiers) {
-        for (const id of topic.identifiers) {
-          const info = variants?.find((v: Variant) => v.identifier === id)
-          const reference = references?.[id]
-          if (info || reference) {
-            const title = info?.title || reference?.title || extractTitleFromIdentifier(id)
-            const url = convertIdentifierToURL(id, references, externalOrigin)
-            const abstract = info?.abstract
-              ? info.abstract.map((a: { text: string }) => a.text).join("")
-              : reference?.abstract
-                ? reference.abstract.map((a: { text: string }) => a.text).join("")
-                : ""
+    if (topic.identifiers) {
+      for (const id of topic.identifiers) {
+        const info = variants?.find((v: Variant) => v.identifier === id)
+        const reference = references?.[id]
+        if (info || reference) {
+          const title = info?.title || reference?.title || extractTitleFromIdentifier(id)
+          const url = convertIdentifierToURL(id, references, externalOrigin)
+          const abstract = info?.abstract
+            ? info.abstract.map((a: { text: string }) => a.text).join("")
+            : reference?.abstract
+              ? reference.abstract.map((a: { text: string }) => a.text).join("")
+              : ""
 
-            const deprecatedLabel = reference?.deprecated ? " *(Deprecated)*" : ""
-            markdown += `- [${title}](${url})${deprecatedLabel}`
-            if (abstract) {
-              markdown += ` ${abstract}`
-            }
-            markdown += "\n"
-          } else {
-            const title = extractTitleFromIdentifier(id)
-            const url = convertIdentifierToURL(id, references, externalOrigin)
-            markdown += `- [${title}](${url})\n`
+          const deprecatedLabel = reference?.deprecated ? " *(Deprecated)*" : ""
+          markdown += `- [${title}](${url})${deprecatedLabel}`
+          if (abstract) {
+            markdown += ` ${abstract}`
           }
+          markdown += "\n"
+        } else {
+          const title = extractTitleFromIdentifier(id)
+          const url = convertIdentifierToURL(id, references, externalOrigin)
+          markdown += `- [${title}](${url})\n`
         }
-        markdown += "\n"
       }
+      markdown += "\n"
     }
   }
 

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -1170,6 +1170,30 @@ describe("Render Function", () => {
     })
   })
 
+  describe("Topic Sections", () => {
+    it("should render topic sections that have no title", async () => {
+      const data = {
+        metadata: { title: "Migration Guide" },
+        topicSections: [
+          {
+            identifiers: ["doc://test/DataRaceSafety", "doc://test/MigrationStrategy"],
+          },
+          {
+            title: "Swift Concurrency in Depth",
+            identifiers: ["doc://test/RuntimeBehavior"],
+          },
+        ],
+      }
+
+      const result = await renderFromJSON(data as any, "https://test.com")
+
+      expect(result).toContain("[Data Race Safety]")
+      expect(result).toContain("[Migration Strategy]")
+      expect(result).toContain("## Swift Concurrency in Depth")
+      expect(result).toContain("[Runtime Behavior]")
+    })
+  })
+
   describe("Platform Information Rendering", () => {
     it("should render platform availability information", async () => {
       const data = {


### PR DESCRIPTION
Resolves #81 

Swift-DocC pages such as the Swift 6 migration guide place their main Topics block in a topic section that has identifiers but no title. The renderer nested the identifier loop inside the title check, so these sections were dropped entirely, hiding most of the guide from agents. Emit the links regardless of title and only add a heading when one exists.