### PR TITLE
Backtick symbol link titles when DocC omits `titleInlineContent`

### DIFF
--- a/src/lib/reference/render.ts
+++ b/src/lib/reference/render.ts
@@ -582,6 +582,8 @@ function renderInlineContent(
 /**
  * Resolve the display title for a reference, preferring its rich
  * `titleInlineContent` (which preserves code spans) over the flat `title`.
+ * When there is no rich title, wrap symbol titles in backticks so older DocC
+ * pages that omit `titleInlineContent` still render code spans in link text.
  */
 function resolveReferenceTitle(
   reference: ContentItem | undefined,
@@ -591,6 +593,9 @@ function resolveReferenceTitle(
 ): string | undefined {
   if (reference?.titleInlineContent) {
     return renderInlineContent(reference.titleInlineContent, references, depth + 1, externalOrigin)
+  }
+  if (reference?.title && reference.role === "symbol") {
+    return `\`${reference.title}\``
   }
   return reference?.title
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,6 +76,11 @@ export interface ContentItem {
   // Structural properties
   level?: number
   style?: string
+  /**
+   * DocC reference role (e.g. `"symbol"`, `"collection"`, `"article"`).
+   * Used to decide whether a plain title should be rendered as a code span.
+   */
+  role?: string
   identifier?: string
   identifiers?: string[]
   url?: string

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -85,7 +85,7 @@ describe("Render Function", () => {
       expect(result).toContain("> **Deprecated**")
       expect(result).toContain("buffer overruns")
       expect(result).toContain(
-        "[getBytes(_:length:)](/documentation/foundation/nsdata/getbytes(_:length:)",
+        "[`getBytes(_:length:)`](/documentation/foundation/nsdata/getbytes(_:length:)",
       )
     })
 
@@ -1074,6 +1074,107 @@ describe("Render Function", () => {
 
       const result = await renderFromJSON(data as any, "https://test.com")
       expect(result).toContain(`[\`revocationType\`](${url})`)
+    })
+
+    it("should backtick inline symbol links that lack titleInlineContent", async () => {
+      const id =
+        "doc://com.apple.documentation/documentation/Metal/MTLAccelerationStructure/gpuResourceID"
+      const url = "/documentation/Metal/MTLAccelerationStructure/gpuResourceID"
+      const data = {
+        metadata: { title: "Release Notes" },
+        primaryContentSections: [
+          {
+            kind: "content",
+            content: [
+              {
+                type: "paragraph",
+                inlineContent: [
+                  { type: "text", text: "Use " },
+                  { type: "reference", identifier: id },
+                  { type: "text", text: " instead." },
+                ],
+              },
+            ],
+          },
+        ],
+        references: {
+          [id]: {
+            type: "topic",
+            kind: "symbol",
+            role: "symbol",
+            title: "gpuResourceID",
+            url,
+            identifier: id,
+          },
+        },
+      }
+
+      const result = await renderFromJSON(data as any, "https://test.com")
+      expect(result).toContain(`[\`gpuResourceID\`](${url})`)
+    })
+
+    it("should not backtick collection references", async () => {
+      const id = "doc://com.apple.documentation/documentation/StoreKit"
+      const url = "/documentation/StoreKit"
+      const data = {
+        metadata: { title: "Release Notes" },
+        primaryContentSections: [
+          {
+            kind: "content",
+            content: [
+              {
+                type: "paragraph",
+                inlineContent: [
+                  { type: "text", text: "See " },
+                  { type: "reference", identifier: id },
+                  { type: "text", text: "." },
+                ],
+              },
+            ],
+          },
+        ],
+        references: {
+          [id]: {
+            type: "topic",
+            kind: "symbol",
+            role: "collection",
+            title: "StoreKit",
+            url,
+            identifier: id,
+          },
+        },
+      }
+
+      const result = await renderFromJSON(data as any, "https://test.com")
+      expect(result).toContain(`[StoreKit](${url})`)
+      expect(result).not.toContain("[`StoreKit`]")
+    })
+
+    it("should backtick symbol links in topic sections", async () => {
+      const id = "doc://test/HStack"
+      const url = "/documentation/SwiftUI/HStack"
+      const data = {
+        metadata: { title: "SwiftUI" },
+        topicSections: [
+          {
+            title: "Containers",
+            identifiers: [id],
+          },
+        ],
+        references: {
+          [id]: {
+            type: "topic",
+            kind: "symbol",
+            role: "symbol",
+            title: "HStack",
+            url,
+            identifier: id,
+          },
+        },
+      }
+
+      const result = await renderFromJSON(data as any, "https://test.com")
+      expect(result).toContain(`- [\`HStack\`](${url})`)
     })
   })
 

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -45,10 +45,10 @@ if (process.env.CI === "1") {
         expect(result).toContain("## Accessing Elements")
 
         // Should contain array-specific methods (note: URLs are lowercase 'swift/array')
-        expect(result).toContain("[init()](/documentation/swift/array/init())")
-        expect(result).toContain("[append(_:)](/documentation/swift/array/append(_:))")
-        expect(result).toContain("[isEmpty](/documentation/swift/array/isempty)") // Note: actual output
-        expect(result).toContain("[count](/documentation/swift/array/count)")
+        expect(result).toContain("[`init()`](/documentation/swift/array/init())")
+        expect(result).toContain("[`append(_:)`](/documentation/swift/array/append(_:))")
+        expect(result).toContain("[`isEmpty`](/documentation/swift/array/isempty)") // Note: actual output
+        expect(result).toContain("[`count`](/documentation/swift/array/count)")
 
         // Footer validation
         expect(result).toContain("*Extracted by [sosumi.ai](https://sosumi.ai)")
@@ -151,9 +151,9 @@ if (process.env.CI === "1") {
         )
 
         // Just verify that method names are properly rendered - don't be too specific
-        expect(result).toContain("[randomElement()]") // Should find this method
-        expect(result).toContain("[isEmpty]") // Should find this property
-        expect(result).toContain("[firstIndex") // Should find methods starting with firstIndex
+        expect(result).toContain("[`randomElement()`]") // Should find this method
+        expect(result).toContain("[`isEmpty`]") // Should find this property
+        expect(result).toContain("[`firstIndex") // Should find methods starting with firstIndex
       },
       TIMEOUT_MS,
     )
@@ -167,14 +167,14 @@ if (process.env.CI === "1") {
         )
 
         // Should preserve method signatures like init(), append(_:), etc.
-        expect(result).toContain("[init()]")
-        expect(result).toContain("[append(_:)]")
-        expect(result).toContain("[insert(_:at:)]")
-        expect(result).toContain("[remove(at:)]")
+        expect(result).toContain("[`init()`]")
+        expect(result).toContain("[`append(_:)`]")
+        expect(result).toContain("[`insert(_:at:)`]")
+        expect(result).toContain("[`remove(at:)`]")
 
         // Should not break method signatures
-        expect(result).not.toContain("[init ()]") // No space before parentheses
-        expect(result).not.toContain("[append (_:)]") // No space before parentheses
+        expect(result).not.toContain("[`init ()`]") // No space before parentheses
+        expect(result).not.toContain("[`append (_:)`]") // No space before parentheses
       },
       TIMEOUT_MS,
     )


### PR DESCRIPTION
Fixes #85 

Older topic references mark symbols with role "symbol" but lack titleInlineContent, so code spans were dropped from link text. Prefer titleInlineContent when present, otherwise wrap plain titles for role "symbol" so collection links stay unformatted.