### PR TITLE
Publish A2A Agent Card for agent-to-agent discovery

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { cache } from "hono/cache"
 import { cors } from "hono/cors"
 import { HTTPException } from "hono/http-exception"
 import { trimTrailingSlash } from "hono/trailing-slash"
+import { buildAgentCard } from "./lib/a2a"
 import {
   decodeExternalTargetPath,
   ExternalAccessError,
@@ -66,7 +67,8 @@ app.use("*", async (c, next) => {
       "Link",
       [
         '</.well-known/api-catalog>; rel="api-catalog"',
-        '</.well-known/mcp/server-card.json>; rel="service-desc"',
+        '</.well-known/agent-card.json>; rel="service-desc"; type="application/json"',
+        '</.well-known/mcp/server-card.json>; rel="service-desc"; type="application/json"',
         '</SKILL.md>; rel="service-doc"',
         '</llms.txt>; rel="alternate"; type="text/markdown"',
       ].join(", "),
@@ -215,6 +217,15 @@ app.get("/.well-known/mcp/server-card.json", (c) => {
       "Content-Type": "application/json; charset=utf-8",
     },
   )
+})
+
+app.get("/.well-known/agent-card.json", (c) => {
+  const origin = new URL(c.req.url).origin
+
+  return c.json(buildAgentCard(origin), 200, {
+    ...discoveryHeaders,
+    "Content-Type": "application/json; charset=utf-8",
+  })
 })
 
 app.get("/webmcp/manifest.json", (c) =>

--- a/src/lib/a2a.ts
+++ b/src/lib/a2a.ts
@@ -1,0 +1,90 @@
+import { MCP_SERVER_INFO, TOOL_DEFINITIONS } from "./mcp"
+
+/**
+ * The A2A protocol version each interface exposes, as `major.minor`.
+ * See https://a2a-protocol.org/latest/specification/
+ */
+const A2A_PROTOCOL_VERSION = "0.3"
+
+/**
+ * The transport binding advertised for the agent's interface.
+ * Sosumi exposes its documentation service over plain HTTP requests,
+ * so the `HTTP+JSON` binding is the closest of A2A's officially supported bindings.
+ */
+const TRANSPORT = "HTTP+JSON"
+
+const AGENT_DESCRIPTION =
+  "Making Apple docs AI-readable. " +
+  "Sosumi converts Apple Developer documentation, Human Interface Guidelines, " +
+  "WWDC session transcripts, and public Swift-DocC sites " +
+  "into clean Markdown for AI agents."
+
+/** Keyword tags describing each skill's capabilities. */
+const SKILL_TAGS: Record<string, string[]> = {
+  searchAppleDocumentation: ["apple", "search", "documentation"],
+  fetchAppleDocumentation: ["apple", "documentation", "markdown", "hig"],
+  fetchExternalDocumentation: ["swift-docc", "documentation", "markdown"],
+  fetchAppleVideoTranscript: ["apple", "wwdc", "video", "transcript"],
+}
+
+/** Example prompts illustrating how each skill is used. */
+const SKILL_EXAMPLES: Record<string, string[]> = {
+  searchAppleDocumentation: ["Search Apple documentation for URLSession"],
+  fetchAppleDocumentation: ["Fetch /documentation/swiftui/view as Markdown"],
+  fetchExternalDocumentation: [
+    "Fetch https://apple.github.io/swift-argument-parser/documentation/argumentparser",
+  ],
+  fetchAppleVideoTranscript: ["Fetch the transcript for /videos/play/wwdc2021/10133"],
+}
+
+interface AgentInterface {
+  url: string
+  /** The A2A protocol version this interface exposes. */
+  protocolVersion: string
+  /** Transport binding. Named `protocolBinding` by the current A2A proto schema. */
+  protocolBinding: string
+  /** Alias of `protocolBinding` for clients reading the published JSON schema's `transport`. */
+  transport: string
+}
+
+/**
+ * Build an A2A Agent Card for the given origin.
+ * Conforms to the A2A Agent Card schema for agent-to-agent discovery.
+ * https://a2a-protocol.org/latest/topics/agent-discovery/
+ */
+export function buildAgentCard(origin: string) {
+  const service: AgentInterface = {
+    url: origin,
+    protocolVersion: A2A_PROTOCOL_VERSION,
+    protocolBinding: TRANSPORT,
+    transport: TRANSPORT,
+  }
+
+  const skills = Object.values(TOOL_DEFINITIONS).map((def) => ({
+    // Convert the camelCase tool name to a kebab-case skill id.
+    id: def.name.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase(),
+    name: def.title,
+    description: def.description,
+    tags: SKILL_TAGS[def.name] ?? ["apple", "documentation"],
+    examples: SKILL_EXAMPLES[def.name],
+  }))
+
+  return {
+    name: MCP_SERVER_INFO.name,
+    description: AGENT_DESCRIPTION,
+    version: MCP_SERVER_INFO.version,
+    supportedInterfaces: [service],
+    provider: {
+      organization: "NSHipster",
+      url: origin,
+    },
+    documentationUrl: `${origin}/SKILL.md`,
+    capabilities: {
+      streaming: false,
+      pushNotifications: false,
+    },
+    defaultInputModes: ["text/plain"],
+    defaultOutputModes: ["text/markdown", "text/plain"],
+    skills,
+  }
+}

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -38,6 +38,52 @@ describe("Agent discovery endpoints", () => {
     expect(card.capabilities.tools).toEqual({})
   })
 
+  it("serves an A2A agent card", async () => {
+    const response = await SELF.fetch("https://sosumi.ai/.well-known/agent-card.json")
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Content-Type")).toContain("application/json")
+
+    const card = (await response.json()) as {
+      name: string
+      version: string
+      description: string
+      supportedInterfaces: Array<{
+        url: string
+        protocolVersion: string
+        protocolBinding: string
+        transport: string
+      }>
+      capabilities: Record<string, unknown>
+      skills: Array<{ id: string; name: string; description: string; tags: string[] }>
+    }
+
+    expect(card.name).toBe("sosumi.ai")
+    expect(card.version).toBeTruthy()
+    expect(card.description).toBeTruthy()
+
+    expect(Array.isArray(card.supportedInterfaces)).toBe(true)
+    expect(card.supportedInterfaces.length).toBeGreaterThan(0)
+    expect(card.supportedInterfaces[0].url).toBe("https://sosumi.ai")
+    expect(card.supportedInterfaces[0].protocolVersion).toBeTruthy()
+    expect(card.supportedInterfaces[0].protocolBinding).toBe("HTTP+JSON")
+    expect(card.supportedInterfaces[0].transport).toBe("HTTP+JSON")
+
+    expect(card.capabilities).toBeTypeOf("object")
+
+    expect(Array.isArray(card.skills)).toBe(true)
+    expect(card.skills.length).toBeGreaterThan(0)
+    for (const skill of card.skills) {
+      expect(skill.id).toBeTruthy()
+      expect(skill.name).toBeTruthy()
+      expect(skill.description).toBeTruthy()
+      expect(Array.isArray(skill.tags)).toBe(true)
+    }
+
+    const searchSkill = card.skills.find((skill) => skill.id === "search-apple-documentation")
+    expect(searchSkill).toBeDefined()
+  })
+
   it("includes Link headers on the homepage", async () => {
     const response = await SELF.fetch("https://sosumi.ai/")
 
@@ -46,5 +92,6 @@ describe("Agent discovery endpoints", () => {
     const link = response.headers.get("Link")
     expect(link).toContain('rel="api-catalog"')
     expect(link).toContain("/.well-known/api-catalog")
+    expect(link).toContain("/.well-known/agent-card.json")
   })
 })

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,7 @@
   "assets": {
     "binding": "ASSETS",
     "directory": "./public",
-    "run_worker_first": ["/", "/.well-known/agent-skills/*"]
+    "run_worker_first": ["/", "/.well-known/agent-card.json", "/.well-known/agent-skills/*"]
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
Serves an A2A Agent Card at `/.well-known/agent-card.json` per the [A2A Protocol specification](https://a2a-protocol.org/latest/specification/), so other agents can discover sosumi's identity, transport interface, capabilities, and skills. The card is built in a new `src/lib/a2a.ts`, deriving its skills from the existing MCP `TOOL_DEFINITIONS` so the discovery surfaces never drift, and is wired up as a Hono route with a homepage `Link` header and a `run_worker_first` entry in `wrangler.jsonc`. Tests in `tests/agent-discovery.test.ts` assert the endpoint returns HTTP 200 JSON with the required `name`/`version`/`description`, a well-formed `supportedInterfaces` entry, `capabilities`, and per-skill `id`/`name`/`description`/`tags`.