### PR TITLE
Implement Web Bot Auth

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,18 @@
+# Web Bot Auth signing key (Ed25519 private key as a JSON Web Key).
+#
+# Generate one with:
+#   openssl genpkey -algorithm ed25519 -out ed25519.pem
+# then convert it to a JWK (kty=OKP, crv=Ed25519, with "x" and "d"),
+# or generate a JWK directly with WebCrypto.
+# The public half is derived automatically
+# and published at /.well-known/http-message-signatures-directory.
+#
+# In production, set this as a secret instead of a plaintext var:
+#   npx wrangler secret put WEB_BOT_AUTH_KEY
+WEB_BOT_AUTH_KEY='{"kty":"OKP","crv":"Ed25519","x":"...","d":"..."}'
+
+# Optional.
+# Origin advertised in the Signature-Agent header
+# and hosting the key directory.
+# Defaults to https://sosumi.ai.
+# SIGNATURE_AGENT=https://sosumi.ai

--- a/README.md
+++ b/README.md
@@ -251,13 +251,16 @@ To enable signing on your own deployment,
 provide an Ed25519 private key (as a JSON Web Key)
 via the `WEB_BOT_AUTH_KEY` secret.
 
-Generate a key (the JSON Web Key is the format `WEB_BOT_AUTH_KEY` expects):
+Generate a key (the JSON Web Key is the format `WEB_BOT_AUTH_KEY` expects),
+then paste the printed value when `wrangler secret put` prompts for it:
 
 ```bash
 node -e 'crypto.subtle.generateKey({name:"Ed25519"},true,["sign","verify"]).then(async k=>{const j=await crypto.subtle.exportKey("jwk",k.privateKey);console.log(JSON.stringify({kty:j.kty,crv:j.crv,x:j.x,d:j.d}))})'
+npx wrangler secret put WEB_BOT_AUTH_KEY
 ```
 
-Then set it as the secret (piping avoids writing the key to disk or shell history):
+Or generate and upload in a single step,
+which avoids writing the key to disk or shell history:
 
 ```bash
 node -e 'crypto.subtle.generateKey({name:"Ed25519"},true,["sign","verify"]).then(async k=>{const j=await crypto.subtle.exportKey("jwk",k.privateKey);console.log(JSON.stringify({kty:j.kty,crv:j.crv,x:j.x,d:j.d}))})' \

--- a/README.md
+++ b/README.md
@@ -234,6 +234,37 @@ with two environment variables (both newline-delimited):
 > Hostname-based private-network checks cannot fully prevent DNS rebinding.
 > Set an explicit `EXTERNAL_DOC_HOST_ALLOWLIST` in production.
 
+### Web Bot Auth
+
+Sosumi identifies itself
+when it fetches from external Swift-DocC hosts on a user's behalf
+using [Web Bot Auth](https://datatracker.ietf.org/wg/webbotauth/about/),
+so those hosts can cryptographically verify the traffic.
+
+- The public key set is published at
+  [`/.well-known/http-message-signatures-directory`](https://sosumi.ai/.well-known/http-message-signatures-directory).
+- Requests to external hosts are signed
+  with an Ed25519 [HTTP Message Signature (RFC 9421)](https://www.rfc-editor.org/rfc/rfc9421)
+  and carry `Signature-Agent`, `Signature-Input`, and `Signature` headers.
+
+To enable signing on your own deployment,
+provide an Ed25519 private key (as a JSON Web Key)
+via the `WEB_BOT_AUTH_KEY` secret:
+
+```bash
+npx wrangler secret put WEB_BOT_AUTH_KEY
+```
+
+The matching public key and its `kid` (JWK thumbprint) are derived automatically,
+so no key material lives in the repository.
+Set the optional `SIGNATURE_AGENT` var to override the advertised origin
+(defaults to `https://sosumi.ai`).
+When no key is configured, requests are simply sent unsigned.
+
+Cloudflare provides
+[built-in verification](https://developers.cloudflare.com/bots/reference/bot-verification/web-bot-auth/)
+for these signatures.
+
 ## Development
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -249,10 +249,19 @@ so those hosts can cryptographically verify the traffic.
 
 To enable signing on your own deployment,
 provide an Ed25519 private key (as a JSON Web Key)
-via the `WEB_BOT_AUTH_KEY` secret:
+via the `WEB_BOT_AUTH_KEY` secret.
+
+Generate a key (the JSON Web Key is the format `WEB_BOT_AUTH_KEY` expects):
 
 ```bash
-npx wrangler secret put WEB_BOT_AUTH_KEY
+node -e 'crypto.subtle.generateKey({name:"Ed25519"},true,["sign","verify"]).then(async k=>{const j=await crypto.subtle.exportKey("jwk",k.privateKey);console.log(JSON.stringify({kty:j.kty,crv:j.crv,x:j.x,d:j.d}))})'
+```
+
+Then set it as the secret (piping avoids writing the key to disk or shell history):
+
+```bash
+node -e 'crypto.subtle.generateKey({name:"Ed25519"},true,["sign","verify"]).then(async k=>{const j=await crypto.subtle.exportKey("jwk",k.privateKey);console.log(JSON.stringify({kty:j.kty,crv:j.crv,x:j.x,d:j.d}))})' \
+  | npx wrangler secret put WEB_BOT_AUTH_KEY
 ```
 
 The matching public key and its `kid` (JWK thumbprint) are derived automatically,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "hono": "^4.9.4",
         "robots-parser": "^3.0.1",
         "tsx": "^4.21.0",
+        "web-bot-auth": "^0.1.3",
         "zod": "^3",
         "zod-to-json-schema": "^3.25.2"
       },
@@ -3380,6 +3381,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-message-sig": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/http-message-sig/-/http-message-sig-0.2.0.tgz",
+      "integrity": "sha512-9fXSmxsdWDuMgk6Rd5Jc8Fa/wEblmRXZyO89KPkRrGsdeAwYlUkvS5oSOw6aOKKK/qKHNTq3jCHHTRCEid6RaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "structured-headers": "2.0.2"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3514,6 +3524,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonwebkey-thumbprint": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsonwebkey-thumbprint/-/jsonwebkey-thumbprint-0.1.0.tgz",
+      "integrity": "sha512-4m/gJEUQH8N2NfvZFjCL8/E+vlt0FlrmHoR4T93CEXQRkC64qwRi6oQri4/eqLVXqEqXYCss0+Q7pLx6vJBqzw==",
+      "license": "Apache-2.0"
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -4543,6 +4559,16 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/structured-headers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-2.0.2.tgz",
+      "integrity": "sha512-IUul56vVHuMg2UxWhwDj9zVJE6ztYEQQkynr1FQ/NydPhivtk5+Qb2N1RS36owEFk2fNUriTguJ2R7htRObcdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18",
+        "npm": ">=6"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -4956,6 +4982,16 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-bot-auth": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/web-bot-auth/-/web-bot-auth-0.1.3.tgz",
+      "integrity": "sha512-gDT9+5aMQbo4A0nNTPvIiN70a4F9iI+NLsmcE14CcTbiUsGgQOAnDZUDHCmDpvIqyJgZWkOcbv+jDvSmhKaIXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-message-sig": "^0.2.0",
+        "jsonwebkey-thumbprint": "^0.1.0"
       }
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "hono": "^4.9.4",
     "robots-parser": "^3.0.1",
     "tsx": "^4.21.0",
+    "web-bot-auth": "^0.1.3",
     "zod": "^3",
     "zod-to-json-schema": "^3.25.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,11 @@ import {
 } from "./lib/skill"
 import { generateAppleDocUrl, isValidAppleDocUrl, normalizeDocumentationPath } from "./lib/url"
 import { fetchVideoTranscriptMarkdown, TranscriptNotFoundError } from "./lib/video"
+import {
+  configureWebBotAuth,
+  DIRECTORY_PATH as WEB_BOT_AUTH_DIRECTORY_PATH,
+  webBotAuthDirectory,
+} from "./lib/webbotauth"
 import { buildWebMcpManifest } from "./lib/webmcp"
 
 interface Env {
@@ -39,11 +44,16 @@ interface Env {
   NODE_ENV: string
   EXTERNAL_DOC_HOST_ALLOWLIST?: string
   EXTERNAL_DOC_HOST_BLOCKLIST?: string
+  WEB_BOT_AUTH_KEY?: string
+  SIGNATURE_AGENT?: string
 }
 
 const app = new Hono<{ Bindings: Env }>()
 
 app.use("*", async (c, next) => {
+  // Prime Web Bot Auth signing before any route or outbound fetch runs.
+  configureWebBotAuth(c.env)
+
   await next()
 
   // Security headers
@@ -156,6 +166,18 @@ app.all(`/.well-known/agent-skills/${SKILL_NAME}/SKILL.md`, async (c) => {
   return new Response(skill.bytes, {
     status: 200,
     headers: skillHeaders,
+  })
+})
+
+app.get(WEB_BOT_AUTH_DIRECTORY_PATH, async (c) => {
+  const directory = await webBotAuthDirectory(c.req.url)
+  if (!directory) {
+    throw new HTTPException(404, { message: "Web Bot Auth key directory is not configured." })
+  }
+
+  return c.json(directory.body, 200, {
+    "Access-Control-Allow-Origin": "*",
+    ...directory.headers,
   })
 })
 

--- a/src/lib/external/fetch.ts
+++ b/src/lib/external/fetch.ts
@@ -1,5 +1,6 @@
 import { renderFromJSON } from "../reference"
 import type { AppleDocJSON } from "../types"
+import { webBotAuthHeaders } from "../webbotauth"
 import {
   assertExternalDocumentationAccess,
   ExternalAccessError,
@@ -42,6 +43,7 @@ export async function fetchExternalDocCJSON(
     headers: {
       "User-Agent": EXTERNAL_DOC_USER_AGENT,
       Accept: "application/json",
+      ...(await webBotAuthHeaders("GET", jsonUrl)),
     },
   })
 
@@ -88,6 +90,7 @@ export async function fetchRobotsPolicy(
     headers: {
       "User-Agent": userAgent,
       Accept: "text/plain, text/*;q=0.9, */*;q=0.1",
+      ...(await webBotAuthHeaders("GET", robotsUrl)),
     },
   })
 

--- a/src/lib/webbotauth.ts
+++ b/src/lib/webbotauth.ts
@@ -99,8 +99,45 @@ export function configureWebBotAuth(env: WebBotAuthEnv): void {
   cache = { key, agent, config: buildConfig(key, agent) }
 }
 
+interface Ed25519PrivateJwk {
+  kty: "OKP"
+  crv: "Ed25519"
+  x: string
+  d: string
+}
+
+/**
+ * Parse and validate the signing secret as an Ed25519 OKP private JWK.
+ * Fails closed on anything malformed
+ * so a misconfigured `WEB_BOT_AUTH_KEY` never yields a broken directory key
+ * or unverifiable signatures.
+ */
+function parseSigningJwk(key: string): Ed25519PrivateJwk {
+  let jwk: JsonWebKey
+  try {
+    jwk = JSON.parse(key) as JsonWebKey
+  } catch (error) {
+    throw new Error(`WEB_BOT_AUTH_KEY is not valid JSON: ${(error as Error).message}`)
+  }
+
+  if (
+    jwk.kty !== "OKP" ||
+    jwk.crv !== "Ed25519" ||
+    typeof jwk.x !== "string" ||
+    jwk.x.length === 0 ||
+    typeof jwk.d !== "string" ||
+    jwk.d.length === 0
+  ) {
+    throw new Error(
+      "WEB_BOT_AUTH_KEY must be an Ed25519 private JSON Web Key (kty=OKP, crv=Ed25519, with x and d).",
+    )
+  }
+
+  return { kty: jwk.kty, crv: jwk.crv, x: jwk.x, d: jwk.d }
+}
+
 async function buildConfig(key: string, agent: string): Promise<WebBotAuthConfig> {
-  const jwk = JSON.parse(key) as JsonWebKey
+  const jwk = parseSigningJwk(key)
   const signer = await signerFromJWK(jwk)
   const kid = await jwkToKeyID(jwk, helpers.WEBCRYPTO_SHA256, helpers.BASE64URL_DECODE)
 
@@ -117,14 +154,21 @@ async function buildConfig(key: string, agent: string): Promise<WebBotAuthConfig
 }
 
 async function currentConfig(): Promise<WebBotAuthConfig | null> {
-  if (!cache) {
+  const entry = cache
+  if (!entry) {
     return null
   }
 
   try {
-    return await cache.config
+    return await entry.config
   } catch (error) {
     console.error("web-bot-auth: failed to load signing key", error)
+    // Drop the failed config so the next request rebuilds it,
+    // rather than serving the cached rejection until the isolate restarts.
+    // Guard against clobbering a newer config set by a concurrent reconfigure.
+    if (cache === entry) {
+      cache = null
+    }
     return null
   }
 }

--- a/src/lib/webbotauth.ts
+++ b/src/lib/webbotauth.ts
@@ -1,0 +1,217 @@
+/**
+ * Web Bot Auth (IETF Web Bot Auth working group) support.
+ *
+ * Two responsibilities:
+ *
+ *  1. Publish a JWKS at `/.well-known/http-message-signatures-directory`
+ *     so receiving sites can look up the public key(s)
+ *     used to verify our signatures.
+ *  2. Sign the requests sosumi.ai makes to external Swift-DocC hosts
+ *     with RFC 9421 HTTP Message Signatures,
+ *     attaching `Signature-Agent`, `Signature-Input`, and `Signature` headers
+ *     so those sites can verify the traffic comes from us.
+ *
+ * The Ed25519 private key is provided out-of-band
+ * as the `WEB_BOT_AUTH_KEY` secret (a JSON Web Key).
+ * The matching public key served in the directory is derived from it,
+ * so no key material lives in the repository.
+ *
+ * See https://datatracker.ietf.org/wg/webbotauth/about/
+ */
+
+import {
+  directoryResponseHeaders,
+  HTTP_MESSAGE_SIGNATURES_DIRECTORY,
+  jwkToKeyID,
+  MediaType,
+  type Signer,
+  signatureHeaders,
+} from "web-bot-auth"
+import { helpers, signerFromJWK } from "web-bot-auth/crypto"
+
+export interface WebBotAuthEnv {
+  /**
+   * Ed25519 private key as a JSON Web Key (JSON string).
+   * Provided as a secret.
+   */
+  WEB_BOT_AUTH_KEY?: string
+  /** Origin advertised in the `Signature-Agent` header and hosting the directory. */
+  SIGNATURE_AGENT?: string
+}
+
+/** Path of the published key directory. */
+export const DIRECTORY_PATH = HTTP_MESSAGE_SIGNATURES_DIRECTORY
+
+/** Content type for the key directory response. */
+export const DIRECTORY_MEDIA_TYPE = MediaType.HTTP_MESSAGE_SIGNATURES_DIRECTORY
+
+const DEFAULT_SIGNATURE_AGENT = "https://sosumi.ai"
+
+/**
+ * How long an outbound request signature stays valid.
+ * Short, to limit replay.
+ */
+const OUTBOUND_SIGNATURE_TTL_MS = 5 * 60 * 1000
+
+/** How long the directory self-signature stays valid. */
+const DIRECTORY_SIGNATURE_TTL_MS = 60 * 60 * 1000
+
+/** A public JSON Web Key as published in the directory (RFC 8037 Ed25519). */
+export interface DirectoryKey {
+  kty?: string
+  crv?: string
+  x?: string
+  kid: string
+  use: string
+}
+
+interface WebBotAuthConfig {
+  signer: Signer
+  publicKey: DirectoryKey
+  agent: string
+}
+
+/**
+ * Cached, parsed configuration.
+ * The signing key is application-global (the same for every request),
+ * so it is memoized across requests in the isolate
+ * and only rebuilt when the underlying secret or agent changes.
+ */
+let cache: { key: string; agent: string; config: Promise<WebBotAuthConfig> } | null = null
+
+/**
+ * Prime the signing configuration from the environment.
+ * Call this once per request,
+ * before any outbound fetch or directory response is produced.
+ */
+export function configureWebBotAuth(env: WebBotAuthEnv): void {
+  const key = env.WEB_BOT_AUTH_KEY?.trim()
+  if (!key) {
+    cache = null
+    return
+  }
+
+  const agent = env.SIGNATURE_AGENT?.trim() || DEFAULT_SIGNATURE_AGENT
+  if (cache && cache.key === key && cache.agent === agent) {
+    return
+  }
+
+  cache = { key, agent, config: buildConfig(key, agent) }
+}
+
+async function buildConfig(key: string, agent: string): Promise<WebBotAuthConfig> {
+  const jwk = JSON.parse(key) as JsonWebKey
+  const signer = await signerFromJWK(jwk)
+  const kid = await jwkToKeyID(jwk, helpers.WEBCRYPTO_SHA256, helpers.BASE64URL_DECODE)
+
+  // Publish only the public half of the key (never the `d` parameter).
+  const publicKey: DirectoryKey = {
+    kty: jwk.kty,
+    crv: jwk.crv,
+    x: jwk.x,
+    kid,
+    use: "sig",
+  }
+
+  return { signer, publicKey, agent }
+}
+
+async function currentConfig(): Promise<WebBotAuthConfig | null> {
+  if (!cache) {
+    return null
+  }
+
+  try {
+    return await cache.config
+  } catch (error) {
+    console.error("web-bot-auth: failed to load signing key", error)
+    return null
+  }
+}
+
+/** Serialize a value as an RFC 8941 structured-field string (a quoted string). */
+function structuredString(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+}
+
+export interface DirectoryResponse {
+  body: { keys: DirectoryKey[] }
+  headers: Record<string, string>
+}
+
+/**
+ * Build the signed key directory response,
+ * or `null` when no key is configured.
+ *
+ * The response body is a JWKS
+ * and carries `Signature`/`Signature-Input` headers
+ * signing over `@authority` with `tag="http-message-signatures-directory"`,
+ * demonstrating control of the published key.
+ */
+export async function webBotAuthDirectory(requestUrl: string): Promise<DirectoryResponse | null> {
+  const config = await currentConfig()
+  if (!config) {
+    return null
+  }
+
+  const created = new Date()
+  const expires = new Date(created.getTime() + DIRECTORY_SIGNATURE_TTL_MS)
+  const message = {
+    response: { status: 200, headers: {} as Record<string, string> },
+    request: { method: "GET", url: requestUrl, headers: {} as Record<string, string> },
+  }
+
+  const signature = await directoryResponseHeaders(message, [config.signer], { created, expires })
+
+  return {
+    body: { keys: [config.publicKey] },
+    headers: {
+      "Content-Type": DIRECTORY_MEDIA_TYPE,
+      Signature: signature.Signature,
+      "Signature-Input": signature["Signature-Input"],
+      "Cache-Control": "public, max-age=300, s-maxage=300",
+    },
+  }
+}
+
+/**
+ * Produce Web Bot Auth headers for an outbound request,
+ * or `{}` when no key is configured (e.g. local development or the CLI).
+ * Signing failures degrade to an unsigned request
+ * rather than breaking the fetch.
+ */
+export async function webBotAuthHeaders(
+  method: string,
+  url: string | URL,
+): Promise<Record<string, string>> {
+  const config = await currentConfig()
+  if (!config) {
+    return {}
+  }
+
+  try {
+    const agent = structuredString(config.agent)
+    // `signature-agent` must be present on the message
+    // so it is covered by the signature;
+    // the same value is returned for the outbound request.
+    const headers = new Headers()
+    headers.set("Signature-Agent", agent)
+
+    const created = new Date()
+    const expires = new Date(created.getTime() + OUTBOUND_SIGNATURE_TTL_MS)
+    const signature = await signatureHeaders(
+      { method, url: url.toString(), headers },
+      config.signer,
+      { created, expires },
+    )
+
+    return {
+      "Signature-Agent": agent,
+      "Signature-Input": signature["Signature-Input"],
+      Signature: signature.Signature,
+    }
+  } catch (error) {
+    console.error("web-bot-auth: failed to sign outbound request", error)
+    return {}
+  }
+}

--- a/tests/webbotauth.test.ts
+++ b/tests/webbotauth.test.ts
@@ -112,3 +112,33 @@ describe("Web Bot Auth request signing", () => {
     expect(await webBotAuthHeaders("GET", "https://example.com/data.json")).toEqual({})
   })
 })
+
+describe("Web Bot Auth configuration validation", () => {
+  it("fails closed on a key missing the private `d` parameter", async () => {
+    // A public-only JWK cannot sign, so it must not be published or used.
+    configureWebBotAuth({ WEB_BOT_AUTH_KEY: JSON.stringify(TEST_PUBLIC_JWK) })
+    expect(await webBotAuthDirectory("https://sosumi.ai/")).toBeNull()
+    expect(await webBotAuthHeaders("GET", "https://example.com/data.json")).toEqual({})
+  })
+
+  it("fails closed on a non-Ed25519 key", async () => {
+    configureWebBotAuth({
+      WEB_BOT_AUTH_KEY: JSON.stringify({ ...TEST_PRIVATE_JWK, crv: "X25519" }),
+    })
+    expect(await webBotAuthDirectory("https://sosumi.ai/")).toBeNull()
+  })
+
+  it("fails closed on malformed JSON", async () => {
+    configureWebBotAuth({ WEB_BOT_AUTH_KEY: "not-json" })
+    expect(await webBotAuthHeaders("GET", "https://example.com/data.json")).toEqual({})
+  })
+
+  it("recovers once a valid key is configured after a bad one", async () => {
+    configureWebBotAuth({ WEB_BOT_AUTH_KEY: "not-json" })
+    expect(await webBotAuthHeaders("GET", "https://example.com/data.json")).toEqual({})
+
+    configureWebBotAuth({ WEB_BOT_AUTH_KEY: JSON.stringify(TEST_PRIVATE_JWK) })
+    const headers = await webBotAuthHeaders("GET", "https://example.com/data.json")
+    expect(headers.Signature).toBeTruthy()
+  })
+})

--- a/tests/webbotauth.test.ts
+++ b/tests/webbotauth.test.ts
@@ -1,0 +1,114 @@
+import { SELF } from "cloudflare:test"
+import { beforeEach, describe, expect, it } from "vitest"
+import { verify } from "web-bot-auth"
+import { verifierFromJWK } from "web-bot-auth/crypto"
+import {
+  configureWebBotAuth,
+  DIRECTORY_MEDIA_TYPE,
+  webBotAuthDirectory,
+  webBotAuthHeaders,
+} from "../src/lib/webbotauth"
+
+// The published RFC 9421 Appendix B.1.4 `test-key-ed25519` vector.
+// Mirrors the JWK configured as WEB_BOT_AUTH_KEY in vitest.config.ts.
+const TEST_PRIVATE_JWK = {
+  kty: "OKP",
+  crv: "Ed25519",
+  x: "JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs",
+  d: "n4Ni-HpISpVObnQMW0wOhCKROaIKqKtW_2ZYb2p9KcU",
+}
+const TEST_PUBLIC_JWK = {
+  kty: TEST_PRIVATE_JWK.kty,
+  crv: TEST_PRIVATE_JWK.crv,
+  x: TEST_PRIVATE_JWK.x,
+}
+
+describe("Web Bot Auth key directory", () => {
+  it("serves a signed JWKS at the well-known path", async () => {
+    const response = await SELF.fetch(
+      "https://sosumi.ai/.well-known/http-message-signatures-directory",
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Content-Type")).toContain(
+      "application/http-message-signatures-directory+json",
+    )
+
+    const directory = (await response.json()) as { keys: Array<Record<string, unknown>> }
+    expect(Array.isArray(directory.keys)).toBe(true)
+    expect(directory.keys.length).toBeGreaterThan(0)
+
+    const [key] = directory.keys
+    expect(key.kty).toBe("OKP")
+    expect(key.crv).toBe("Ed25519")
+    expect(typeof key.x).toBe("string")
+    expect(typeof key.kid).toBe("string")
+    // Never publish private key material.
+    expect(key.d).toBeUndefined()
+
+    // The directory response signs over itself.
+    expect(response.headers.get("Signature")).toBeTruthy()
+    expect(response.headers.get("Signature-Input")).toContain(
+      'tag="http-message-signatures-directory"',
+    )
+  })
+
+  it("builds a directory whose kid matches the published key", async () => {
+    configureWebBotAuth({ WEB_BOT_AUTH_KEY: JSON.stringify(TEST_PRIVATE_JWK) })
+
+    const directory = await webBotAuthDirectory(
+      "https://sosumi.ai/.well-known/http-message-signatures-directory",
+    )
+    expect(directory).not.toBeNull()
+    expect(directory?.headers["Content-Type"]).toBe(DIRECTORY_MEDIA_TYPE)
+
+    const key = directory?.body.keys[0]
+    expect(key?.x).toBe(TEST_PRIVATE_JWK.x)
+    expect(key?.kid).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(key).not.toHaveProperty("d")
+  })
+
+  it("returns null when no signing key is configured", async () => {
+    configureWebBotAuth({})
+    expect(await webBotAuthDirectory("https://sosumi.ai/")).toBeNull()
+  })
+})
+
+describe("Web Bot Auth request signing", () => {
+  beforeEach(() => {
+    configureWebBotAuth({ WEB_BOT_AUTH_KEY: JSON.stringify(TEST_PRIVATE_JWK) })
+  })
+
+  it("produces verifiable Signature headers for an outbound request", async () => {
+    const url = "https://developer.apple.com/tutorials/data/documentation/swift.json"
+    const headers = await webBotAuthHeaders("GET", url)
+
+    expect(headers["Signature-Agent"]).toBe('"https://sosumi.ai"')
+    expect(headers["Signature-Input"]).toContain('"@authority"')
+    expect(headers["Signature-Input"]).toContain('"signature-agent"')
+    expect(headers["Signature-Input"]).toContain('alg="ed25519"')
+    expect(headers["Signature-Input"]).toContain('tag="web-bot-auth"')
+    expect(headers["Signature-Input"]).toMatch(/keyid="[A-Za-z0-9_-]+"/)
+    expect(headers.Signature).toMatch(/^sig1=:.+:$/)
+
+    // A receiving site reconstructs the request
+    // and verifies the signature with the public key from the directory.
+    const message = { method: "GET", url, headers: new Headers(headers) }
+    await expect(verify(message, await verifierFromJWK(TEST_PUBLIC_JWK))).resolves.not.toThrow()
+  })
+
+  it("uses a configurable signature agent", async () => {
+    configureWebBotAuth({
+      WEB_BOT_AUTH_KEY: JSON.stringify(TEST_PRIVATE_JWK),
+      SIGNATURE_AGENT: "https://docs.example.com",
+    })
+
+    const headers = await webBotAuthHeaders("GET", "https://example.com/data.json")
+    expect(headers["Signature-Agent"]).toBe('"https://docs.example.com"')
+  })
+
+  it("returns no headers when no signing key is configured", async () => {
+    configureWebBotAuth({})
+    expect(await webBotAuthHeaders("GET", "https://example.com/data.json")).toEqual({})
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,17 @@ export default defineWorkersConfig({
     poolOptions: {
       workers: {
         wrangler: { configPath: "./wrangler.jsonc" },
+        miniflare: {
+          bindings: {
+            // The published RFC 9421 Appendix B.1.4 `test-key-ed25519` vector,
+            // used for Web Bot Auth signing tests.
+            // It is a well-known test key (its public half is the example in
+            // Cloudflare's own Web Bot Auth docs), so it does not trip secret
+            // scanners.
+            WEB_BOT_AUTH_KEY:
+              '{"kty":"OKP","crv":"Ed25519","x":"JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs","d":"n4Ni-HpISpVObnQMW0wOhCKROaIKqKtW_2ZYb2p9KcU"}',
+          },
+        },
       },
     },
     // Handle CommonJS modules properly


### PR DESCRIPTION
Adds [Web Bot Auth](https://datatracker.ietf.org/wg/webbotauth/about/) so sosumi.ai can identify itself when fetching on a user's behalf. Publishes a signed Ed25519 JWKS at `/.well-known/http-message-signatures-directory` and signs outbound requests to external Swift-DocC hosts with RFC 9421 HTTP Message Signatures (`Signature-Agent`, `Signature-Input`, `Signature`), which receiving sites (e.g. via Cloudflare) can verify. The signing key is supplied through the `WEB_BOT_AUTH_KEY` secret and its public key/`kid` are derived at runtime, so no key material lives in the repo; when unset, requests are sent unsigned. Tests use the published RFC 9421 test vector and cover the directory response plus a full sign-then-verify round trip.