### PR TITLE
Render tabbed content in Human Interface Guidelines pages

### DIFF
--- a/src/lib/hig/render.ts
+++ b/src/lib/hig/render.ts
@@ -331,9 +331,16 @@ function renderHIGTabNavigator(
   for (const tab of tabs) {
     // Tabs usually repeat their title as a heading in their own content,
     // so only add a label when the title would otherwise be lost.
+    // A leading heading only stands in for the label when it repeats the title,
+    // possibly with a qualifier, as in "Small" and "Small (default 38mm)".
     const label = tab.title?.trim()
-    const leadsWithHeading = tab.content?.[0]?.type === "heading"
-    if (label && !leadsWithHeading) {
+    const first = tab.content?.[0]
+    const leadingHeading = first?.type === "heading" ? (first.text ?? "").trim() : undefined
+    const headingRepeatsTitle =
+      label !== undefined &&
+      leadingHeading !== undefined &&
+      leadingHeading.toLowerCase().startsWith(label.toLowerCase())
+    if (label && !headingRepeatsTitle) {
       markdown += `**${label}**\n\n`
     }
     if (tab.content?.length) {

--- a/src/lib/hig/render.ts
+++ b/src/lib/hig/render.ts
@@ -269,6 +269,8 @@ function renderContentItem(
     markdown += renderHIGTable(item, references, depth)
   } else if (item.type === "aside") {
     markdown += renderHIGAside(item, references, depth)
+  } else if (item.type === "tabNavigator") {
+    markdown += renderHIGTabNavigator(item, references, depth)
   } else if (item.type === "row") {
     markdown += renderHIGRow(item, references, depth)
   } else if (item.type === "video") {
@@ -309,6 +311,36 @@ function renderHIGAside(
   const rawType = (aside.style || aside.name || "note").toLowerCase()
   const asideContent = item.content ? renderHIGContent(item.content, references, depth + 1) : ""
   return formatCallout(mapAsideStyleToCallout(rawType), asideContent)
+}
+
+/**
+ * Render a HIG tabNavigator by flattening its tabs into a sequence.
+ * Only one tab is visible at a time on the web,
+ * so rendering them all keeps the content of every tab
+ * (such as the per-Dynamic Type size tables on the Typography page).
+ */
+function renderHIGTabNavigator(
+  item: ContentItem,
+  references: Record<string, HIGReference | HIGImageReference | HIGExternalReference>,
+  depth: number = 0,
+): string {
+  const tabs = item.tabs ?? []
+  if (tabs.length === 0) return ""
+
+  let markdown = ""
+  for (const tab of tabs) {
+    // Tabs usually repeat their title as a heading in their own content,
+    // so only add a label when the title would otherwise be lost.
+    const label = tab.title?.trim()
+    const leadsWithHeading = tab.content?.[0]?.type === "heading"
+    if (label && !leadsWithHeading) {
+      markdown += `**${label}**\n\n`
+    }
+    if (tab.content?.length) {
+      markdown += renderHIGContent(tab.content, references, depth + 1)
+    }
+  }
+  return markdown
 }
 
 /**

--- a/tests/hig.test.ts
+++ b/tests/hig.test.ts
@@ -604,6 +604,108 @@ describe("HIG Module", () => {
       )
     })
 
+    it("should render every tab of a HIG tab navigator", async () => {
+      const tabTable = (style: string, size: string) => ({
+        type: "table",
+        header: "row",
+        rows: [
+          [
+            [{ type: "paragraph", inlineContent: [{ type: "text", text: "Style" }] }],
+            [{ type: "paragraph", inlineContent: [{ type: "text", text: "Size (points)" }] }],
+          ],
+          [
+            [{ type: "paragraph", inlineContent: [{ type: "text", text: style }] }],
+            [{ type: "paragraph", inlineContent: [{ type: "text", text: size }] }],
+          ],
+        ],
+      })
+
+      const testData = {
+        ...higGettingStartedData,
+        primaryContentSections: [
+          {
+            kind: "content" as const,
+            content: [
+              {
+                type: "tabNavigator",
+                tabs: [
+                  {
+                    title: "xSmall",
+                    content: [
+                      { type: "heading", level: 4, anchor: "xSmall", text: "xSmall" },
+                      tabTable("Large Title", "31"),
+                    ],
+                  },
+                  {
+                    title: "Large (default)",
+                    content: [
+                      {
+                        type: "heading",
+                        level: 4,
+                        anchor: "Large-default",
+                        text: "Large (default)",
+                      },
+                      tabTable("Large Title", "34"),
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      } as HIGPageJSON
+
+      const result = await renderHIGFromJSON(
+        testData,
+        "https://developer.apple.com/design/human-interface-guidelines/typography",
+      )
+
+      expect(result).toContain("#### xSmall")
+      expect(result).toContain("| Large Title | 31 |")
+      expect(result).toContain("#### Large (default)")
+      expect(result).toContain("| Large Title | 34 |")
+      // The tabs already lead with their own headings, so no label is repeated.
+      expect(result).not.toContain("**xSmall**")
+    })
+
+    it("should label HIG tabs that don't lead with a heading", async () => {
+      const testData = {
+        ...higGettingStartedData,
+        primaryContentSections: [
+          {
+            kind: "content" as const,
+            content: [
+              {
+                type: "tabNavigator",
+                tabs: [
+                  {
+                    title: "SF Pro",
+                    content: [
+                      { type: "paragraph", inlineContent: [{ type: "text", text: "Neutral" }] },
+                    ],
+                  },
+                  {
+                    title: "New York",
+                    content: [
+                      { type: "paragraph", inlineContent: [{ type: "text", text: "Serif" }] },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      } as HIGPageJSON
+
+      const result = await renderHIGFromJSON(
+        testData,
+        "https://developer.apple.com/design/human-interface-guidelines/typography",
+      )
+
+      expect(result).toContain("**SF Pro**\n\nNeutral")
+      expect(result).toContain("**New York**\n\nSerif")
+    })
+
     it("should render HIG asides and row columns", async () => {
       const testData = {
         ...higGettingStartedData,

--- a/tests/hig.test.ts
+++ b/tests/hig.test.ts
@@ -706,6 +706,49 @@ describe("HIG Module", () => {
       expect(result).toContain("**New York**\n\nSerif")
     })
 
+    it("should keep the HIG tab label when the tab leads with an unrelated heading", async () => {
+      const testData = {
+        ...higGettingStartedData,
+        primaryContentSections: [
+          {
+            kind: "content" as const,
+            content: [
+              {
+                type: "tabNavigator",
+                tabs: [
+                  {
+                    title: "Small",
+                    content: [
+                      { type: "heading", level: 4, text: "Small (default 38mm)" },
+                      { type: "paragraph", inlineContent: [{ type: "text", text: "Compact" }] },
+                    ],
+                  },
+                  {
+                    title: "Large",
+                    content: [
+                      { type: "heading", level: 4, text: "Overview" },
+                      { type: "paragraph", inlineContent: [{ type: "text", text: "Roomy" }] },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      } as HIGPageJSON
+
+      const result = await renderHIGFromJSON(
+        testData,
+        "https://developer.apple.com/design/human-interface-guidelines/typography",
+      )
+
+      // A heading that repeats the title stands in for the label.
+      expect(result).not.toContain("**Small**")
+      expect(result).toContain("#### Small (default 38mm)\n\nCompact")
+      // An unrelated heading does not, so the title is kept.
+      expect(result).toContain("**Large**\n\n#### Overview\n\nRoomy")
+    })
+
     it("should render HIG asides and row columns", async () => {
       const testData = {
         ...higGettingStartedData,


### PR DESCRIPTION
Fixes #91.

HIG pages wrap some tables in a tabNavigator block, one tab per Dynamic Type size, and the HIG renderer had no branch for that type. Everything inside those tabs was silently dropped, which is why the Typography page rendered its macOS text styles table but none of the iOS ones.

This flattens a tabNavigator into its tabs, rendered in order, so no tab's content is lost. Apple's tabs already repeat their title as a heading in their own content, so a bold label is only added when a tab doesn't lead with one.

The reference renderer already handled tabNavigator this way; this brings the HIG renderer in line.