### PR TITLE
Annotate reference pages with deployment target availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ https://sosumi.ai/documentation/swift/array
 This works for all API reference docs,
 as well as Apple's [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/) (HIG).
 
+#### Deployment Targets
+
+Reference pages accept optional `platform` and `osVersion` query parameters:
+
+```
+https://sosumi.ai/documentation/appkit/nsapplication/activate()?platform=macOS&osVersion=13.0
+```
+
+The rendered Markdown gains a `**Deployment target:**` line saying whether the symbol
+is available, deprecated, or not yet introduced on that target:
+
+```
+**Deployment target:** macOS 13.0 (not available; introduced in macOS 14.0)
+```
+
+Supported platforms are `iOS`, `iPadOS`, `Mac Catalyst`, `macOS`, `tvOS`, `visionOS`, and `watchOS`.
+
+> [!NOTE]
+> Apple publishes only the current revision of each page,
+> so this annotates the latest documentation with availability metadata.
+> It does not reconstruct how a page read on an older SDK.
+
 WWDC session transcripts are also supported by replacing the same host for video URLs:
 
 **Original:**
@@ -94,6 +116,7 @@ See [the website](https://sosumi.ai/#clients) for client-specific instructions.
 
 - `fetchAppleDocumentation` - Fetches Apple Developer documentation and Human Interface Guidelines by path
   - Parameters: `path` (string) - Documentation path (e.g., '/documentation/swift', '/documentation/swiftui/view', '/design/human-interface-guidelines/foundations/color')
+  - Optional parameters: `platform` (string) and `osVersion` (string) - deployment target used to annotate availability
   - Returns content as Markdown
 
 - `fetchAppleVideoTranscript` - Fetches video transcripts, including WWDC sessions

--- a/public/SKILL.md
+++ b/public/SKILL.md
@@ -47,6 +47,20 @@ Replace `developer.apple.com` with `sosumi.ai`:
   - `https://sosumi.ai/documentation/swift/array`
   - `https://sosumi.ai/documentation/swiftui/view`
 
+### Deployment Targets
+
+Apple publishes only the current revision of each page,
+so Sosumi cannot show a page as it read on an older SDK.
+It can say whether a symbol applies to the OS you are targeting.
+
+- Pattern: `https://sosumi.ai/documentation/{framework}/{symbol}?platform={platform}&osVersion={version}`
+- Platforms: `iOS`, `iPadOS`, `Mac Catalyst`, `macOS`, `tvOS`, `visionOS`, `watchOS`
+- Example: `https://sosumi.ai/documentation/appkit/nsapplication/activate()?platform=macOS&osVersion=13.0`
+
+The response adds a `**Deployment target:**` line, for example
+`**Deployment target:** macOS 13.0 (not available; introduced in macOS 14.0)`.
+Putting a version in a search `query` does not filter results; use these parameters instead.
+
 ### Human Interface Guidelines
 
 - Pattern: `https://sosumi.ai/design/human-interface-guidelines/{topic}`
@@ -75,7 +89,7 @@ Use these when Sosumi is configured as an MCP server (`https://sosumi.ai/mcp`):
 | Tool | Parameters | Use |
 |---|---|---|
 | `searchAppleDocumentation` | `query: string` | Search Apple documentation and return structured results |
-| `fetchAppleDocumentation` | `path: string` | Fetch Apple docs or HIG content by path as Markdown |
+| `fetchAppleDocumentation` | `path: string`, optional `platform: string`, `osVersion: string` | Fetch Apple docs or HIG content by path as Markdown |
 | `fetchAppleVideoTranscript` | `path: string` | Fetch Apple video transcript by `/videos/play/...` path |
 | `fetchExternalDocumentation` | `url: string` | Fetch external Swift-DocC page by absolute HTTPS URL |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,12 @@ import {
   renderHIGTableOfContents,
 } from "./lib/hig"
 import { createMcpServer, MCP_SERVER_INFO } from "./lib/mcp"
-import { fetchJSONData, renderFromJSON } from "./lib/reference"
+import {
+  fetchJSONData,
+  parseDeploymentTarget,
+  renderFromJSON,
+  UNSUPPORTED_DEPLOYMENT_TARGET_MESSAGE,
+} from "./lib/reference"
 import { searchAppleDeveloperDocs } from "./lib/search"
 import {
   createSkillIndex,
@@ -343,8 +348,25 @@ This service only works with Apple Developer documentation URLs:
     throw new HTTPException(400, { res: errorResponse })
   }
 
+  // Optional deployment target, so callers can ask about the OS they actually ship against
+  const platformParam = c.req.query("platform")?.trim()
+  const osVersionParam = c.req.query("osVersion")?.trim()
+  if (!platformParam && osVersionParam) {
+    throw new HTTPException(400, {
+      message: "The osVersion parameter requires a platform parameter.",
+    })
+  }
+  const deploymentTarget = platformParam
+    ? parseDeploymentTarget(platformParam, osVersionParam)
+    : undefined
+  if (platformParam && !deploymentTarget) {
+    throw new HTTPException(400, { message: UNSUPPORTED_DEPLOYMENT_TARGET_MESSAGE })
+  }
+
   const jsonData = await fetchJSONData(path)
-  const markdown = await renderFromJSON(jsonData, appleUrl)
+  const markdown = await renderFromJSON(jsonData, appleUrl, {
+    deploymentTarget: deploymentTarget ?? undefined,
+  })
 
   // Validate that we got meaningful content
   if (!markdown || markdown.trim().length < 100) {

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -98,7 +98,7 @@ export const TOOL_DEFINITIONS = {
         ),
     },
     annotations: readOnlyAnnotations,
-    http: { pathFrom: "path" },
+    http: { pathFrom: "path", query: { platform: "platform", osVersion: "osVersion" } },
   },
   fetchExternalDocumentation: {
     name: "fetchExternalDocumentation",
@@ -222,6 +222,11 @@ export function createMcpServer(externalPolicyEnv: ExternalPolicyEnv = {}) {
     },
     async ({ path, platform, osVersion }) => {
       try {
+        // Mirror the HTTP route: a version on its own has nothing to apply to,
+        // so reject it rather than quietly rendering for the latest SDK.
+        if (osVersion && !platform) {
+          throw new Error("The osVersion parameter requires a platform parameter.")
+        }
         const deploymentTarget = platform ? parseDeploymentTarget(platform, osVersion) : undefined
         if (platform && !deploymentTarget) {
           throw new Error(UNSUPPORTED_DEPLOYMENT_TARGET_MESSAGE)

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -4,7 +4,13 @@ import { z } from "zod"
 import type { ExternalPolicyEnv } from "./external"
 import { fetchExternalDocumentationMarkdown } from "./external"
 import { fetchHIGPageData, renderHIGFromJSON } from "./hig"
-import { fetchJSONData, renderFromJSON } from "./reference"
+import {
+  fetchJSONData,
+  parseDeploymentTarget,
+  renderFromJSON,
+  SUPPORTED_PLATFORM_NAMES,
+  UNSUPPORTED_DEPLOYMENT_TARGET_MESSAGE,
+} from "./reference"
 import { searchAppleDeveloperDocs } from "./search"
 import { generateAppleDocUrl, normalizeDocumentationPath } from "./url"
 import { fetchVideoTranscriptMarkdown } from "./video"
@@ -77,6 +83,18 @@ export const TOOL_DEFINITIONS = {
         .string()
         .describe(
           "Documentation path (e.g., '/documentation/swift', '/documentation/swiftui/view', '/design/human-interface-guidelines/foundations/color')",
+        ),
+      platform: z
+        .string()
+        .optional()
+        .describe(
+          `Optional deployment target platform (${SUPPORTED_PLATFORM_NAMES.join(", ")}). Annotates the page with whether the symbol is available on that platform.`,
+        ),
+      osVersion: z
+        .string()
+        .optional()
+        .describe(
+          "Optional deployment target OS version (e.g., '14.5'). Requires platform. Apple publishes only current pages, so this annotates availability rather than showing an older revision.",
         ),
     },
     annotations: readOnlyAnnotations,
@@ -202,8 +220,13 @@ export function createMcpServer(externalPolicyEnv: ExternalPolicyEnv = {}) {
       inputSchema: fetchDocs.inputSchema,
       annotations: fetchDocs.annotations,
     },
-    async ({ path }) => {
+    async ({ path, platform, osVersion }) => {
       try {
+        const deploymentTarget = platform ? parseDeploymentTarget(platform, osVersion) : undefined
+        if (platform && !deploymentTarget) {
+          throw new Error(UNSUPPORTED_DEPLOYMENT_TARGET_MESSAGE)
+        }
+
         if (path.includes("design/human-interface-guidelines")) {
           const higPath = path.replace(/^\/?(design\/human-interface-guidelines\/)/, "")
           const sourceUrl = `https://developer.apple.com/design/human-interface-guidelines/${higPath}`
@@ -229,7 +252,9 @@ export function createMcpServer(externalPolicyEnv: ExternalPolicyEnv = {}) {
         const appleUrl = generateAppleDocUrl(normalizedPath)
 
         const jsonData = await fetchJSONData(normalizedPath)
-        const markdown = await renderFromJSON(jsonData, appleUrl)
+        const markdown = await renderFromJSON(jsonData, appleUrl, {
+          deploymentTarget: deploymentTarget ?? undefined,
+        })
 
         if (!markdown || markdown.trim().length < 100) {
           throw new Error("Insufficient content in documentation")

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -277,6 +277,7 @@ export function createMcpServer(externalPolicyEnv: ExternalPolicyEnv = {}) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error"
 
         return {
+          isError: true,
           content: [
             {
               type: "text" as const,

--- a/src/lib/reference/availability.ts
+++ b/src/lib/reference/availability.ts
@@ -1,0 +1,205 @@
+/**
+ * Deployment target awareness for Apple DocC availability metadata.
+ *
+ * Apple's DocC JSON is always a snapshot of the current SDK.
+ * It carries no historical revision of a page,
+ * so "show me this page as it read on macOS 14.5" is not answerable from this data.
+ * What every symbol does carry is per-platform availability
+ * (`introducedAt`, `deprecatedAt`, `beta`, `unavailable`),
+ * which is enough to answer the question agents actually need:
+ * does this symbol exist on the platform and version I am targeting?
+ */
+
+import type { Platform } from "./types"
+
+/** A platform, and optionally an OS version, that a caller is building against. */
+export interface DeploymentTarget {
+  /** Canonical Apple platform name, for example `"macOS"`. */
+  platform: string
+  /** Dotted version string, for example `"14.5"`. Absent means the latest SDK. */
+  version?: string
+}
+
+export type AvailabilityStatus =
+  /** The symbol exists on the target. */
+  | "available"
+  /** The symbol exists but is deprecated as of the target. */
+  | "deprecated"
+  /** The symbol was introduced after the target. */
+  | "unintroduced"
+  /** The symbol is not offered on the target platform at all. */
+  | "unavailable"
+  /** The page carries no platform metadata, as with articles and collections. */
+  | "unknown"
+
+export interface AvailabilityVerdict {
+  status: AvailabilityStatus
+  /** Human-readable explanation, rendered in parentheses after the target. */
+  detail: string
+}
+
+/** Platform names as Apple spells them in DocC `metadata.platforms`. */
+export const SUPPORTED_PLATFORM_NAMES = [
+  "iOS",
+  "iPadOS",
+  "Mac Catalyst",
+  "macOS",
+  "tvOS",
+  "visionOS",
+  "watchOS",
+] as const
+
+/** Spellings callers are likely to use, mapped to Apple's own. */
+const PLATFORM_ALIASES = new Map<string, string>([
+  ["ios", "iOS"],
+  ["iphoneos", "iOS"],
+  ["ipados", "iPadOS"],
+  ["maccatalyst", "Mac Catalyst"],
+  ["mac catalyst", "Mac Catalyst"],
+  ["catalyst", "Mac Catalyst"],
+  ["macos", "macOS"],
+  ["osx", "macOS"],
+  ["mac os x", "macOS"],
+  ["tvos", "tvOS"],
+  ["visionos", "visionOS"],
+  ["xros", "visionOS"],
+  ["watchos", "watchOS"],
+])
+
+const VERSION_PATTERN = /^\d+(\.\d+)*$/
+
+export const UNSUPPORTED_DEPLOYMENT_TARGET_MESSAGE =
+  `Unsupported platform or version. ` +
+  `Supported platforms: ${SUPPORTED_PLATFORM_NAMES.join(", ")}. ` +
+  `Versions are dotted numbers, for example 14.5.`
+
+/**
+ * Compare two dotted version strings.
+ * Missing components count as zero, so `26` and `26.0` are equal.
+ */
+export function compareVersions(a: string, b: string): number {
+  const left = a.split(".")
+  const right = b.split(".")
+  const length = Math.max(left.length, right.length)
+
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = Number.parseInt(left[index] ?? "0", 10) || 0
+    const rightPart = Number.parseInt(right[index] ?? "0", 10) || 0
+    if (leftPart !== rightPart) {
+      return leftPart < rightPart ? -1 : 1
+    }
+  }
+
+  return 0
+}
+
+/**
+ * Resolve a caller-supplied platform and version into a deployment target.
+ * Returns `null` when the platform is not one Apple documents,
+ * or when the version is not a dotted number.
+ */
+export function parseDeploymentTarget(
+  platform?: string | null,
+  osVersion?: string | null,
+): DeploymentTarget | null {
+  const name = platform?.trim()
+  if (!name) {
+    return null
+  }
+
+  const canonical = PLATFORM_ALIASES.get(name.toLowerCase())
+  if (!canonical) {
+    return null
+  }
+
+  const version = osVersion?.trim()
+  if (!version) {
+    return { platform: canonical }
+  }
+
+  if (!VERSION_PATTERN.test(version)) {
+    return null
+  }
+
+  return { platform: canonical, version }
+}
+
+/**
+ * Format one platform's availability for the page header.
+ * Deprecated APIs get a closed range so the window is visible at a glance,
+ * rather than only in the deprecation callout further down.
+ */
+export function formatPlatformAvailability(platform: Platform): string {
+  if (platform.unavailable) {
+    return `${platform.name} (unavailable)`
+  }
+
+  const introducedAt = platform.introducedAt?.trim()
+  if (platform.deprecatedAt) {
+    const range = introducedAt ? `${introducedAt}-${platform.deprecatedAt}` : platform.deprecatedAt
+    return `${platform.name} ${range} (deprecated)`
+  }
+
+  const base = introducedAt ? `${platform.name} ${introducedAt}+` : platform.name
+  if (platform.deprecated) {
+    return `${base} (deprecated)`
+  }
+
+  return platform.beta ? `${base} Beta` : base
+}
+
+/**
+ * Decide whether a page's symbol is usable on the requested deployment target.
+ */
+export function evaluateAvailability(
+  platforms: Platform[] | undefined,
+  target: DeploymentTarget,
+): AvailabilityVerdict {
+  if (!platforms?.length) {
+    return {
+      status: "unknown",
+      detail: "no platform availability information on this page",
+    }
+  }
+
+  const match = platforms.find(
+    (platform) => platform.name.toLowerCase() === target.platform.toLowerCase(),
+  )
+  if (!match || match.unavailable) {
+    return { status: "unavailable", detail: `not available on ${target.platform}` }
+  }
+
+  const introducedAt = match.introducedAt?.trim()
+  if (target.version && introducedAt && compareVersions(target.version, introducedAt) < 0) {
+    return {
+      status: "unintroduced",
+      detail: `not available; introduced in ${match.name} ${introducedAt}`,
+    }
+  }
+
+  // Without a requested version the caller is asking about the latest SDK,
+  // where any recorded deprecation already applies.
+  if (match.deprecatedAt) {
+    if (!target.version || compareVersions(target.version, match.deprecatedAt) >= 0) {
+      return {
+        status: "deprecated",
+        detail: `deprecated as of ${match.name} ${match.deprecatedAt}`,
+      }
+    }
+  } else if (match.deprecated) {
+    return { status: "deprecated", detail: `deprecated on ${match.name}` }
+  }
+
+  const since = introducedAt ? `available since ${match.name} ${introducedAt}` : "available"
+  return { status: "available", detail: match.beta ? `${since}, beta` : since }
+}
+
+/** Render the deployment target line that precedes a page's body. */
+export function formatDeploymentTargetLine(
+  platforms: Platform[] | undefined,
+  target: DeploymentTarget,
+): string {
+  const label = target.version ? `${target.platform} ${target.version}` : target.platform
+  const { detail } = evaluateAvailability(platforms, target)
+  return `**Deployment target:** ${label} (${detail})`
+}

--- a/src/lib/reference/index.ts
+++ b/src/lib/reference/index.ts
@@ -3,6 +3,7 @@
  * Re-exports all reference documentation related functions and types
  */
 
+export * from "./availability"
 export * from "./fetch"
 export * from "./render"
 export type * from "./types"

--- a/src/lib/reference/render.ts
+++ b/src/lib/reference/render.ts
@@ -14,6 +14,11 @@ import {
   mapAsideStyleToCallout,
 } from "../markdown"
 import { extractTitleFromIdentifier } from "../url"
+import {
+  type DeploymentTarget,
+  formatDeploymentTargetLine,
+  formatPlatformAvailability,
+} from "./availability"
 import type {
   AppleDocJSON,
   ContentItem,
@@ -28,6 +33,8 @@ import type {
 
 interface RenderOptions {
   externalOrigin?: string
+  /** Platform and version the caller is building against, if they named one. */
+  deploymentTarget?: DeploymentTarget
 }
 
 /**
@@ -62,10 +69,13 @@ export async function renderFromJSON(
 
   // Add platform availability
   if (jsonData.metadata?.platforms && jsonData.metadata.platforms.length > 0) {
-    const platforms = jsonData.metadata.platforms
-      .map((p) => `${p.name} ${p.introducedAt}+${p.beta ? " Beta" : ""}`)
-      .join(", ")
+    const platforms = jsonData.metadata.platforms.map(formatPlatformAvailability).join(", ")
     markdown += `**Available on:** ${platforms}\n\n`
+  }
+
+  // Add the caller's deployment target and how this page's availability applies to it
+  if (options.deploymentTarget) {
+    markdown += `${formatDeploymentTargetLine(jsonData.metadata?.platforms, options.deploymentTarget)}\n\n`
   }
 
   // Add abstract

--- a/tests/availability.test.ts
+++ b/tests/availability.test.ts
@@ -1,0 +1,222 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: pedantic type check */
+import { SELF } from "cloudflare:test"
+import { describe, expect, it } from "vitest"
+import {
+  compareVersions,
+  evaluateAvailability,
+  formatPlatformAvailability,
+  parseDeploymentTarget,
+  renderFromJSON,
+  SUPPORTED_PLATFORM_NAMES,
+} from "../src/lib/reference"
+
+describe("compareVersions", () => {
+  it("orders dotted versions numerically", () => {
+    expect(compareVersions("14.5", "14.0")).toBeGreaterThan(0)
+    expect(compareVersions("9.0", "10.0")).toBeLessThan(0)
+    expect(compareVersions("14.0", "14.0")).toBe(0)
+  })
+
+  it("treats missing components as zero", () => {
+    expect(compareVersions("26", "26.0")).toBe(0)
+    expect(compareVersions("26.0.1", "26")).toBeGreaterThan(0)
+  })
+})
+
+describe("parseDeploymentTarget", () => {
+  it("canonicalizes platform names case-insensitively", () => {
+    expect(parseDeploymentTarget("macos", "14.5")).toEqual({
+      platform: "macOS",
+      version: "14.5",
+    })
+    expect(parseDeploymentTarget("IOS", "17")).toEqual({ platform: "iOS", version: "17" })
+    expect(parseDeploymentTarget("mac catalyst", undefined)).toEqual({
+      platform: "Mac Catalyst",
+    })
+  })
+
+  it("returns null for unsupported platforms", () => {
+    expect(parseDeploymentTarget("windows", "11")).toBeNull()
+    expect(parseDeploymentTarget("", "14.5")).toBeNull()
+  })
+
+  it("returns null for malformed versions", () => {
+    expect(parseDeploymentTarget("macOS", "sonoma")).toBeNull()
+    expect(parseDeploymentTarget("macOS", "14.x")).toBeNull()
+  })
+
+  it("exposes the supported platform names", () => {
+    expect(SUPPORTED_PLATFORM_NAMES).toContain("macOS")
+    expect(SUPPORTED_PLATFORM_NAMES).toContain("visionOS")
+  })
+})
+
+describe("formatPlatformAvailability", () => {
+  it("renders an open-ended range for current APIs", () => {
+    expect(formatPlatformAvailability({ name: "macOS", introducedAt: "14.0" })).toBe("macOS 14.0+")
+  })
+
+  it("keeps the beta marker", () => {
+    expect(formatPlatformAvailability({ name: "macOS", introducedAt: "27.0", beta: true })).toBe(
+      "macOS 27.0+ Beta",
+    )
+  })
+
+  it("renders a closed range when the API is deprecated", () => {
+    expect(
+      formatPlatformAvailability({ name: "macOS", introducedAt: "10.0", deprecatedAt: "27.0" }),
+    ).toBe("macOS 10.0-27.0 (deprecated)")
+  })
+
+  it("marks deprecation without a version", () => {
+    expect(formatPlatformAvailability({ name: "iOS", introducedAt: "2.0", deprecated: true })).toBe(
+      "iOS 2.0+ (deprecated)",
+    )
+  })
+
+  it("marks unavailable platforms", () => {
+    expect(formatPlatformAvailability({ name: "tvOS", introducedAt: "", unavailable: true })).toBe(
+      "tvOS (unavailable)",
+    )
+  })
+})
+
+describe("evaluateAvailability", () => {
+  const platforms = [
+    { name: "macOS", introducedAt: "10.0", deprecatedAt: "27.0" },
+    { name: "iOS", introducedAt: "14.0" },
+  ]
+
+  it("reports symbols that predate the deployment target as available", () => {
+    expect(evaluateAvailability(platforms, { platform: "macOS", version: "14.5" })).toEqual({
+      status: "available",
+      detail: "available since macOS 10.0",
+    })
+  })
+
+  it("reports symbols introduced after the deployment target", () => {
+    expect(evaluateAvailability(platforms, { platform: "iOS", version: "13.0" })).toEqual({
+      status: "unintroduced",
+      detail: "not available; introduced in iOS 14.0",
+    })
+  })
+
+  it("reports symbols deprecated by the deployment target", () => {
+    expect(evaluateAvailability(platforms, { platform: "macOS", version: "27.0" })).toEqual({
+      status: "deprecated",
+      detail: "deprecated as of macOS 27.0",
+    })
+  })
+
+  it("reports platforms the page does not cover", () => {
+    expect(evaluateAvailability(platforms, { platform: "watchOS", version: "10.0" })).toEqual({
+      status: "unavailable",
+      detail: "not available on watchOS",
+    })
+  })
+
+  it("honors an explicit unavailable flag", () => {
+    expect(
+      evaluateAvailability([{ name: "tvOS", introducedAt: "", unavailable: true }], {
+        platform: "tvOS",
+      }),
+    ).toEqual({ status: "unavailable", detail: "not available on tvOS" })
+  })
+
+  it("falls back to the latest SDK when no version is given", () => {
+    expect(evaluateAvailability(platforms, { platform: "macOS" })).toEqual({
+      status: "deprecated",
+      detail: "deprecated as of macOS 27.0",
+    })
+  })
+
+  it("notes beta availability", () => {
+    expect(
+      evaluateAvailability([{ name: "macOS", introducedAt: "27.0", beta: true }], {
+        platform: "macOS",
+        version: "27.0",
+      }),
+    ).toEqual({ status: "available", detail: "available since macOS 27.0, beta" })
+  })
+
+  it("reports pages with no platform metadata as unknown", () => {
+    expect(evaluateAvailability(undefined, { platform: "macOS", version: "14.5" })).toEqual({
+      status: "unknown",
+      detail: "no platform availability information on this page",
+    })
+  })
+})
+
+describe("renderFromJSON with a deployment target", () => {
+  const deprecatedSymbol = {
+    metadata: {
+      title: "activate(ignoringOtherApps:)",
+      platforms: [{ name: "macOS", introducedAt: "10.0", deprecatedAt: "27.0" }],
+    },
+  }
+
+  it("renders deprecation ranges in the availability line", async () => {
+    const result = await renderFromJSON(deprecatedSymbol as any, "https://test.com")
+
+    expect(result).toContain("**Available on:** macOS 10.0-27.0 (deprecated)")
+  })
+
+  it("annotates the page for the requested deployment target", async () => {
+    const result = await renderFromJSON(deprecatedSymbol as any, "https://test.com", {
+      deploymentTarget: { platform: "macOS", version: "14.5" },
+    })
+
+    expect(result).toContain("**Deployment target:** macOS 14.5 (available since macOS 10.0)")
+  })
+
+  it("flags symbols that do not exist yet on the deployment target", async () => {
+    const data = {
+      metadata: {
+        title: "activate()",
+        platforms: [{ name: "macOS", introducedAt: "14.0" }],
+      },
+    }
+
+    const result = await renderFromJSON(data as any, "https://test.com", {
+      deploymentTarget: { platform: "macOS", version: "13.0" },
+    })
+
+    expect(result).toContain(
+      "**Deployment target:** macOS 13.0 (not available; introduced in macOS 14.0)",
+    )
+  })
+
+  it("omits the deployment target line when none is requested", async () => {
+    const result = await renderFromJSON(deprecatedSymbol as any, "https://test.com")
+
+    expect(result).not.toContain("**Deployment target:**")
+  })
+})
+
+describe("HTTP deployment target parameters", () => {
+  it("rejects an unsupported platform", async () => {
+    const response = await SELF.fetch(
+      "https://sosumi.ai/documentation/appkit/nsapplication?platform=windows",
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("Unsupported platform or version")
+  })
+
+  it("rejects a malformed version", async () => {
+    const response = await SELF.fetch(
+      "https://sosumi.ai/documentation/appkit/nsapplication?platform=macOS&osVersion=sonoma",
+    )
+
+    expect(response.status).toBe(400)
+  })
+
+  it("rejects osVersion without a platform", async () => {
+    const response = await SELF.fetch(
+      "https://sosumi.ai/documentation/appkit/nsapplication?osVersion=14.5",
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("platform")
+  })
+})

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const toolHandlers = new Map<string, (input: unknown) => Promise<unknown>>()
 const fetchVideoTranscriptMarkdown = vi.fn()
 const searchAppleDeveloperDocs = vi.fn()
+const fetchJSONData = vi.fn()
+const renderFromJSON = vi.fn()
 
 vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => {
   class McpServerMock {
@@ -28,11 +30,53 @@ vi.mock("../src/lib/search", () => ({
   searchAppleDeveloperDocs,
 }))
 
+vi.mock("../src/lib/reference", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/lib/reference")>()
+  return { ...actual, fetchJSONData, renderFromJSON }
+})
+
 describe("MCP tools registration", () => {
   beforeEach(() => {
     toolHandlers.clear()
     fetchVideoTranscriptMarkdown.mockReset()
     searchAppleDeveloperDocs.mockReset()
+    fetchJSONData.mockReset()
+    renderFromJSON.mockReset()
+  })
+
+  it("passes an optional deployment target through to the renderer", async () => {
+    fetchJSONData.mockResolvedValue({ metadata: { title: "activate()" } })
+    renderFromJSON.mockResolvedValue(`# activate()\n\n${"A".repeat(150)}`)
+
+    const { createMcpServer } = await import("../src/lib/mcp")
+    createMcpServer()
+
+    const handler = toolHandlers.get("fetchAppleDocumentation")
+    await handler?.({
+      path: "/documentation/appkit/nsapplication/activate()",
+      platform: "macos",
+      osVersion: "14.5",
+    })
+
+    expect(renderFromJSON).toHaveBeenCalledWith(
+      expect.anything(),
+      "https://developer.apple.com/documentation/appkit/nsapplication/activate()",
+      { deploymentTarget: { platform: "macOS", version: "14.5" } },
+    )
+  })
+
+  it("returns a readable error for an unsupported deployment target", async () => {
+    const { createMcpServer } = await import("../src/lib/mcp")
+    createMcpServer()
+
+    const handler = toolHandlers.get("fetchAppleDocumentation")
+    const result = (await handler?.({
+      path: "/documentation/appkit/nsapplication",
+      platform: "windows",
+    })) as { content: Array<{ text: string }> }
+
+    expect(fetchJSONData).not.toHaveBeenCalled()
+    expect(result.content[0].text).toContain("Unsupported platform or version")
   })
 
   it("registers and runs fetchAppleVideoTranscript with path input", async () => {

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -65,6 +65,21 @@ describe("MCP tools registration", () => {
     )
   })
 
+  it("rejects osVersion without platform instead of ignoring it", async () => {
+    const { createMcpServer } = await import("../src/lib/mcp")
+    createMcpServer()
+
+    const handler = toolHandlers.get("fetchAppleDocumentation")
+    const result = (await handler?.({
+      path: "/documentation/appkit/nsapplication",
+      osVersion: "14.5",
+    })) as { isError?: boolean; content: Array<{ text: string }> }
+
+    expect(fetchJSONData).not.toHaveBeenCalled()
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain("requires a platform")
+  })
+
   it("returns a readable error for an unsupported deployment target", async () => {
     const { createMcpServer } = await import("../src/lib/mcp")
     createMcpServer()

--- a/tests/webmcp.test.ts
+++ b/tests/webmcp.test.ts
@@ -26,6 +26,18 @@ describe("WebMCP", () => {
     expect(tools[2].inputSchema.properties).toHaveProperty("url")
   })
 
+  it("describes the deployment target query parameters for fetchAppleDocumentation", async () => {
+    const response = await SELF.fetch("https://sosumi.ai/webmcp/manifest.json")
+    const tools = (await response.json()) as Array<{
+      name: string
+      http: { pathFrom?: string; query?: Record<string, string> }
+    }>
+
+    const fetchTool = tools.find((tool) => tool.name === "fetchAppleDocumentation")
+    expect(fetchTool?.http.pathFrom).toBe("path")
+    expect(fetchTool?.http.query).toEqual({ platform: "platform", osVersion: "osVersion" })
+  })
+
   it("serves a static WebMCP bootstrap script", async () => {
     const response = await SELF.fetch("https://sosumi.ai/webmcp.js")
 


### PR DESCRIPTION
Related to #93

Apple only publishes the current revision of each page, so "docs as of macOS 14.5" is not reachable from its DocC JSON. Per-symbol availability metadata is, and that answers most of what the issue is really after.

- `/documentation/*` and the `fetchAppleDocumentation` MCP tool take optional `platform` and `osVersion` parameters.
- The rendered Markdown gains a `**Deployment target:**` line: available, deprecated, not yet introduced, or unavailable on that platform.
- The existing `**Available on:**` line now shows a closed range for deprecated APIs, so `activate(ignoringOtherApps:)` reads `macOS 10.0-27.0 (deprecated)`.
- Unsupported platforms or malformed versions get a 400 rather than being silently ignored.
- Search filtering is left out: results carry no availability data, so it would mean fetching every hit.