### PR TITLE
Move search to Apple's /api/v1/query endpoint

### DIFF
--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -175,19 +175,17 @@ export function createMcpServer(externalPolicyEnv: ExternalPolicyEnv = {}) {
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error"
 
-        const structuredContent = {
-          query,
-          results: [],
-        }
-
+        // Report the failure as an error rather than as structured content.
+        // An empty `results` array reads as "this documentation does not exist",
+        // which would leave the caller trusting its own memory instead of looking again.
         return {
+          isError: true,
           content: [
             {
               type: "text" as const,
               text: `Error searching Apple Developer documentation: ${errorMessage}`,
             },
           ],
-          structuredContent,
         }
       }
     },

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -15,14 +15,24 @@ export interface SearchResponse {
 }
 
 // Apple's current search backend, discovered from
-// https://developer.apple.com/search/scripts/search.js (May 2026)
+// https://developer.apple.com/search/scripts/search.js (September 2026)
 //
 // Historical context:
 //   - The legacy /search/ HTML scraper broke when Apple switched to a JS-rendered SPA
 //   - PR #54 upstream (NSHipster/sosumi.ai) targeted /search/services/search.php with
 //     NDJSON-style streamed events; that endpoint is now also gone (404)
-//   - The current backend is a plain JSON POST API on Apple's MSC infrastructure
-const APPLE_SEARCH_SERVICE_URL = "https://devintserv.msc.sbz.apple.com/api/v1/search"
+//   - /api/v1/search replaced it, and now 404s in turn
+//   - The current backend is /api/v1/query, which answers only in JSONL:
+//     one event per line, each tagged with a `kind`
+const APPLE_SEARCH_SERVICE_URL = "https://devintserv.msc.sbz.apple.com/api/v1/query"
+
+// The backend rejects a request that does not name the response channels it wants.
+// `quickSearch` carries the top typeahead matches in a single event;
+// `search` streams the full ranked list.
+// The third channel Apple's own page requests, `ask`, is a generated answer,
+// which is not what this service reports.
+const INCLUDED_RESPONSES = ["quickSearch", "search"]
+
 const DEFAULT_TARGET_RESULT_LOCALE = "en"
 const TARGET_RESULT_LOCALE_BY_BASE_NAME = new Map([
   ["en", "en"],
@@ -49,7 +59,7 @@ async function searchAppleDeveloperDocsViaService(query: string): Promise<Search
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Accept: "application/json",
+      Accept: "application/jsonl",
       // The MSC backend requires a browser-style Origin/Referer pair to accept the request.
       Origin: "https://developer.apple.com",
       Referer: "https://developer.apple.com/search/",
@@ -58,6 +68,7 @@ async function searchAppleDeveloperDocsViaService(query: string): Promise<Search
     body: JSON.stringify({
       text: query,
       targetResultLocale: resolveTargetResultLocale(),
+      includedResponses: INCLUDED_RESPONSES,
     }),
   })
 
@@ -65,36 +76,104 @@ async function searchAppleDeveloperDocsViaService(query: string): Promise<Search
     throw new Error(`Search request failed: ${response.status}`)
   }
 
-  const data = await readSearchResponseJson(response)
-  const rawResults = Array.isArray(data.results) ? (data.results as unknown[]) : []
-  return extractSearchResults(rawResults)
+  return extractSearchResults(await readSearchResponseItems(response))
 }
 
-async function readSearchResponseJson(response: Response): Promise<JsonRecord> {
+// The response body is JSONL: one JSON object per line.
+// A `quickSearch` event carries its results inline,
+// while `search` events stream the full list as diffs against a JSON text buffer,
+// so those results can only be read once every line has been applied.
+// Events of any other kind — `quickSearchFinished`, `searchFinished`, `ask` —
+// are not part of the result set and are skipped.
+async function readSearchResponseItems(response: Response): Promise<unknown[]> {
+  const items: unknown[] = []
+  let streamedSearch = ""
+
+  for (const line of (await response.text()).split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed) {
+      continue
+    }
+
+    const event = parseJson(trimmed)
+    if (!isJsonRecord(event)) {
+      continue
+    }
+
+    if (event.kind === "quickSearch") {
+      items.push(...resultsOf(event.response))
+    } else if (event.kind === "search") {
+      streamedSearch = applySearchDiff(streamedSearch, event.diff)
+    }
+  }
+
+  if (streamedSearch) {
+    items.push(...resultsOf(parseJson(streamedSearch)))
+  }
+
+  return items
+}
+
+// Each `search` event appends to the buffer,
+// after dropping `removeLast` characters from the end of what came before.
+function applySearchDiff(buffer: string, diff: unknown): string {
+  if (!isJsonRecord(diff)) {
+    return buffer
+  }
+
+  const removeLast = typeof diff.removeLast === "number" ? diff.removeLast : 0
+  const append = typeof diff.append === "string" ? diff.append : ""
+
+  return buffer.slice(0, Math.max(0, buffer.length - removeLast)) + append
+}
+
+function parseJson(text: string): unknown {
   try {
-    const data = await response.json()
-    return isJsonRecord(data) ? data : {}
+    return JSON.parse(text)
   } catch {
     throw new Error("Search response was not valid JSON")
   }
 }
 
+function resultsOf(container: unknown): unknown[] {
+  if (!isJsonRecord(container)) {
+    return []
+  }
+
+  return Array.isArray(container.results) ? container.results : []
+}
+
+// The same page can be reported by more than one channel,
+// so keep the first mention of each URL and drop the rest.
 function extractSearchResults(items: unknown[]): SearchResult[] {
+  const seen = new Set<string>()
+
   return items.flatMap((item) => {
     const result = normalizeSearchResult(item)
-    return result ? [result] : []
+    if (!result || seen.has(result.url)) {
+      return []
+    }
+
+    seen.add(result.url)
+    return [result]
   })
 }
 
+// A result is `{ metadata, origin }`, and its `metadata.metadataKind` says how to read it:
+//   - "documentation" for reference pages, with singular fields
+//   - "developer" for WWDC sessions and other media, with parallel arrays
+//   - "webPage" for marketing and swift.org pages, keyed by `sourceURL`
 function normalizeSearchResult(item: unknown): SearchResult | null {
-  if (!isJsonRecord(item)) {
+  const record = unwrapResultValue(item)
+  if (!record || !isJsonRecord(record.metadata)) {
     return null
   }
 
-  const documentation = extractMetadataRecord(item.documentation)
-  if (documentation) {
-    const title = stringValue(documentation.title)
-    const url = stringValue(documentation.permalink)
+  const metadata = record.metadata
+
+  if (metadata.metadataKind === "documentation") {
+    const title = stringValue(metadata.title)
+    const url = stringValue(metadata.permalink)
     if (!title || !url) {
       return null
     }
@@ -102,17 +181,16 @@ function normalizeSearchResult(item: unknown): SearchResult | null {
     return {
       title,
       url,
-      description: stringValue(documentation.description) ?? "",
-      breadcrumbs: splitHierarchy(stringValue(documentation.hierarchy)),
-      tags: compactStrings([stringValue(documentation.kind)]),
+      description: stringValue(metadata.description) ?? "",
+      breadcrumbs: splitHierarchy(stringValue(metadata.hierarchy)),
+      tags: compactStrings([stringValue(metadata.kind)]),
       type: "documentation",
     }
   }
 
-  const developer = extractMetadataRecord(item.developer)
-  if (developer) {
-    const title = firstString(developer.titles)
-    const url = firstString(developer.permalinks)
+  if (metadata.metadataKind === "developer") {
+    const title = firstString(metadata.titles)
+    const url = firstString(metadata.permalinks)
     if (!title || !url) {
       return null
     }
@@ -120,20 +198,19 @@ function normalizeSearchResult(item: unknown): SearchResult | null {
     return {
       title,
       url,
-      description: firstString(developer.descriptions) ?? "",
-      breadcrumbs: compactStrings([firstString(developer.projectNames)]),
+      description: firstString(metadata.descriptions) ?? "",
+      breadcrumbs: compactStrings([firstString(metadata.projectNames)]),
       tags: compactStrings([
-        firstString(developer.itemTypes),
-        firstString(developer.deliveryLanguageCodes),
+        firstString(metadata.itemTypes),
+        firstString(metadata.deliveryLanguageCodes),
       ]),
-      type: (firstString(developer.itemTypes) ?? "developer").toLowerCase(),
+      type: (firstString(metadata.itemTypes) ?? "developer").toLowerCase(),
     }
   }
 
-  const devsite = extractMetadataRecord(item.devsite)
-  if (devsite) {
-    const title = stringValue(devsite.title)
-    const url = stringValue(devsite.sourceURL)
+  if (metadata.metadataKind === "webPage") {
+    const title = stringValue(metadata.title)
+    const url = stringValue(metadata.sourceURL)
     if (!title || !url) {
       return null
     }
@@ -141,25 +218,7 @@ function normalizeSearchResult(item: unknown): SearchResult | null {
     return {
       title,
       url,
-      description: stringValue(devsite.description) ?? "",
-      breadcrumbs: [],
-      tags: [],
-      type: "general",
-    }
-  }
-
-  const swiftdocs = extractMetadataRecord(item.swiftdocs)
-  if (swiftdocs) {
-    const title = stringValue(swiftdocs.title)
-    const url = stringValue(swiftdocs.sourceURL)
-    if (!title || !url) {
-      return null
-    }
-
-    return {
-      title,
-      url,
-      description: stringValue(swiftdocs.description) ?? "",
+      description: stringValue(metadata.description) ?? "",
       breadcrumbs: [],
       tags: [],
       type: "general",
@@ -169,13 +228,14 @@ function normalizeSearchResult(item: unknown): SearchResult | null {
   return null
 }
 
-function extractMetadataRecord(container: unknown): JsonRecord | null {
-  if (!isJsonRecord(container)) {
+// Streamed `search` results wrap their payload in `value` alongside a match excerpt,
+// while `quickSearch` results carry it directly.
+function unwrapResultValue(item: unknown): JsonRecord | null {
+  if (!isJsonRecord(item)) {
     return null
   }
 
-  const metadata = container.metadata
-  return isJsonRecord(metadata) ? metadata : null
+  return isJsonRecord(item.value) ? item.value : item
 }
 
 function isJsonRecord(value: unknown): value is JsonRecord {

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -125,4 +125,24 @@ describe("MCP tools registration", () => {
     expect(result.structuredContent.query).toBe("SchemaMigrationPlan")
     expect(result.structuredContent.results[0]?.title).toBe("SchemaMigrationPlan")
   })
+
+  it("reports an upstream search failure as an error rather than an empty result set", async () => {
+    searchAppleDeveloperDocs.mockRejectedValue(new Error("Search request failed: 404"))
+
+    const { createMcpServer } = await import("../src/lib/mcp")
+    createMcpServer()
+
+    const handler = toolHandlers.get("searchAppleDocumentation")
+    const result = (await handler?.({ query: "WKWebView" })) as {
+      isError?: boolean
+      content: Array<{ text: string }>
+      structuredContent?: { query: string; results: unknown[] }
+    }
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain("Search request failed: 404")
+    // An empty `results` array would read as "no such documentation exists",
+    // which is exactly the answer the caller must not trust here.
+    expect(result.structuredContent).toBeUndefined()
+  })
 })

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,7 +1,35 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { searchAppleDeveloperDocs } from "../src/lib/search"
 
-const SEARCH_URL = "https://devintserv.msc.sbz.apple.com/api/v1/search"
+const SEARCH_URL = "https://devintserv.msc.sbz.apple.com/api/v1/query"
+
+function jsonlResponse(lines: unknown[]): Response {
+  const body = lines
+    .map((line) => (typeof line === "string" ? line : JSON.stringify(line)))
+    .join("\n")
+
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/jsonl" },
+  })
+}
+
+// Split a "search" payload into diff events the way Apple's backend streams them:
+// each event appends to a buffer after dropping `removeLast` characters from its end.
+function searchDiffEvents(payload: unknown): unknown[] {
+  const serialized = JSON.stringify(payload)
+  const midpoint = Math.floor(serialized.length / 2)
+  const speculative = "PARTIAL"
+
+  return [
+    { kind: "search", diff: { append: serialized.slice(0, midpoint), removeLast: 0 } },
+    { kind: "search", diff: { append: speculative, removeLast: 0 } },
+    {
+      kind: "search",
+      diff: { append: serialized.slice(midpoint), removeLast: speculative.length },
+    },
+  ]
+}
 
 describe("searchAppleDeveloperDocs", () => {
   const originalFetch = global.fetch
@@ -15,11 +43,12 @@ describe("searchAppleDeveloperDocs", () => {
     global.fetch = originalFetch
   })
 
-  it("parses the JSON response from Apple's MSC search backend", async () => {
-    const payload = {
-      results: [
-        {
-          documentation: {
+  it("parses the JSONL response from Apple's MSC query backend", async () => {
+    const quickSearch = {
+      kind: "quickSearch",
+      response: {
+        results: [
+          {
             metadata: {
               title: "SchemaMigrationPlan",
               permalink: "https://developer.apple.com/documentation/swiftdata/schemamigrationplan",
@@ -27,11 +56,43 @@ describe("searchAppleDeveloperDocs", () => {
                 "An interface for describing the evolution of a schema and how to migrate between specific versions.",
               hierarchy: "SwiftData > SchemaMigrationPlan",
               kind: "symbol",
+              metadataKind: "documentation",
             },
+            origin: "documentation",
+          },
+          {
+            metadata: {
+              title: "Get Started - SwiftUI",
+              sourceURL: "https://developer.apple.com/swiftui/get-started/",
+              description: "SwiftUI provides everything you need to begin designing.",
+              metadataKind: "webPage",
+            },
+            origin: "developerWeb",
+          },
+        ],
+      },
+    }
+
+    const streamedSearch = {
+      results: [
+        {
+          excerpt: "An interface for describing the evolution of a schema",
+          value: {
+            metadata: {
+              title: "SchemaMigrationPlan",
+              permalink: "https://developer.apple.com/documentation/swiftdata/schemamigrationplan",
+              description:
+                "An interface for describing the evolution of a schema and how to migrate between specific versions.",
+              hierarchy: "SwiftData > SchemaMigrationPlan",
+              kind: "symbol",
+              metadataKind: "documentation",
+            },
+            origin: "documentation",
           },
         },
         {
-          developer: {
+          excerpt: "Learn how to use schema macros",
+          value: {
             metadata: {
               titles: ["Model your schema with SwiftData"],
               permalinks: ["https://developer.apple.com/videos/play/wwdc2023/10195"],
@@ -39,36 +100,37 @@ describe("searchAppleDeveloperDocs", () => {
               projectNames: ["WWDC23"],
               itemTypes: ["Video"],
               deliveryLanguageCodes: ["eng"],
+              metadataKind: "developer",
             },
+            origin: "developerWWDC",
           },
         },
         {
-          devsite: {
-            metadata: {
-              title: "Get Started - SwiftUI",
-              sourceURL: "https://developer.apple.com/swiftui/get-started/",
-              description: "SwiftUI provides everything you need to begin designing.",
-            },
-          },
-        },
-        {
-          swiftdocs: {
+          excerpt: "",
+          value: {
             metadata: {
               title: "Swift.org - The Swift Programming Language",
               sourceURL: "https://www.swift.org/documentation/",
               description: "Documentation for the Swift programming language.",
+              metadataKind: "webPage",
             },
+            origin: "swift",
           },
         },
       ],
     }
 
-    global.fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify(payload), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    )
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        jsonlResponse([
+          quickSearch,
+          { kind: "quickSearchFinished" },
+          "",
+          ...searchDiffEvents(streamedSearch),
+          { kind: "searchFinished" },
+        ]),
+      )
 
     const result = await searchAppleDeveloperDocs("SchemaMigrationPlan")
 
@@ -80,7 +142,7 @@ describe("searchAppleDeveloperDocs", () => {
         method: "POST",
         headers: expect.objectContaining({
           "Content-Type": "application/json",
-          Accept: "application/json",
+          Accept: "application/jsonl",
           Origin: "https://developer.apple.com",
           Referer: "https://developer.apple.com/search/",
           "User-Agent": expect.stringMatching(/AppleWebKit/),
@@ -90,8 +152,10 @@ describe("searchAppleDeveloperDocs", () => {
     expect(JSON.parse(String(requestInit?.body))).toEqual({
       text: "SchemaMigrationPlan",
       targetResultLocale: expect.any(String),
+      includedResponses: ["quickSearch", "search"],
     })
 
+    // The documentation result appears in both channels, and is reported once.
     expect(result).toEqual({
       query: "SchemaMigrationPlan",
       results: [
@@ -105,20 +169,20 @@ describe("searchAppleDeveloperDocs", () => {
           type: "documentation",
         },
         {
-          title: "Model your schema with SwiftData",
-          url: "https://developer.apple.com/videos/play/wwdc2023/10195",
-          description: "Learn how to use schema macros and migration plans with SwiftData.",
-          breadcrumbs: ["WWDC23"],
-          tags: ["Video", "eng"],
-          type: "video",
-        },
-        {
           title: "Get Started - SwiftUI",
           url: "https://developer.apple.com/swiftui/get-started/",
           description: "SwiftUI provides everything you need to begin designing.",
           breadcrumbs: [],
           tags: [],
           type: "general",
+        },
+        {
+          title: "Model your schema with SwiftData",
+          url: "https://developer.apple.com/videos/play/wwdc2023/10195",
+          description: "Learn how to use schema macros and migration plans with SwiftData.",
+          breadcrumbs: ["WWDC23"],
+          tags: ["Video", "eng"],
+          type: "video",
         },
         {
           title: "Swift.org - The Swift Programming Language",
@@ -132,6 +196,51 @@ describe("searchAppleDeveloperDocs", () => {
     })
   })
 
+  it("ignores results carried by response kinds it did not ask for", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      jsonlResponse([
+        {
+          kind: "ask",
+          response: {
+            results: [
+              {
+                metadata: {
+                  title: "Generated answer",
+                  permalink: "https://developer.apple.com/generated",
+                  metadataKind: "documentation",
+                },
+                origin: "documentation",
+              },
+            ],
+          },
+        },
+        {
+          kind: "quickSearch",
+          response: {
+            results: [
+              {
+                metadata: {
+                  title: "WKWebView",
+                  permalink: "https://developer.apple.com/documentation/webkit/wkwebview",
+                  description: "An object that displays interactive web content.",
+                  hierarchy: "WebKit > WKWebView",
+                  kind: "symbol",
+                  metadataKind: "documentation",
+                },
+                origin: "documentation",
+              },
+            ],
+          },
+        },
+      ]),
+    )
+
+    const result = await searchAppleDeveloperDocs("WKWebView")
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0]?.title).toBe("WKWebView")
+  })
+
   it("collapses 'en-*' locales to bare 'en' to match Apple's accepted target locales", async () => {
     vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
       () =>
@@ -140,12 +249,9 @@ describe("searchAppleDeveloperDocs", () => {
         }) as Intl.DateTimeFormat,
     )
 
-    global.fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ results: [] }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    )
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(jsonlResponse([{ kind: "quickSearch", response: { results: [] } }]))
 
     await searchAppleDeveloperDocs("SchemaMigrationPlan")
 
@@ -153,6 +259,7 @@ describe("searchAppleDeveloperDocs", () => {
     expect(JSON.parse(String(requestInit?.body))).toEqual({
       text: "SchemaMigrationPlan",
       targetResultLocale: "en",
+      includedResponses: ["quickSearch", "search"],
     })
   })
 
@@ -164,12 +271,9 @@ describe("searchAppleDeveloperDocs", () => {
         }) as Intl.DateTimeFormat,
     )
 
-    global.fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ results: [] }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    )
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(jsonlResponse([{ kind: "quickSearch", response: { results: [] } }]))
 
     await searchAppleDeveloperDocs("Foundation")
 
@@ -177,6 +281,7 @@ describe("searchAppleDeveloperDocs", () => {
     expect(JSON.parse(String(requestInit?.body))).toEqual({
       text: "Foundation",
       targetResultLocale: "ja-JP",
+      includedResponses: ["quickSearch", "search"],
     })
   })
 
@@ -188,12 +293,9 @@ describe("searchAppleDeveloperDocs", () => {
         }) as Intl.DateTimeFormat,
     )
 
-    global.fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ results: [] }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    )
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(jsonlResponse([{ kind: "quickSearch", response: { results: [] } }]))
 
     await searchAppleDeveloperDocs("Foundation")
 
@@ -201,16 +303,20 @@ describe("searchAppleDeveloperDocs", () => {
     expect(JSON.parse(String(requestInit?.body))).toEqual({
       text: "Foundation",
       targetResultLocale: "es-lamr",
+      includedResponses: ["quickSearch", "search"],
     })
   })
 
   it("returns an empty result set when Apple search returns no matches", async () => {
-    global.fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ results: [] }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    )
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        jsonlResponse([
+          { kind: "quickSearch", response: { results: [] } },
+          { kind: "quickSearchFinished" },
+          { kind: "searchFinished" },
+        ]),
+      )
 
     const result = await searchAppleDeveloperDocs("no-such-symbol")
 
@@ -221,12 +327,11 @@ describe("searchAppleDeveloperDocs", () => {
   })
 
   it("returns an empty result set when the response omits the results array", async () => {
-    global.fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ featuredResults: [] }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    )
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        jsonlResponse([{ kind: "quickSearch", response: { featuredResults: [] } }]),
+      )
 
     const result = await searchAppleDeveloperDocs("ambiguous-shape")
 
@@ -247,11 +352,22 @@ describe("searchAppleDeveloperDocs", () => {
     await expect(searchAppleDeveloperDocs("anything")).rejects.toThrow("Search request failed: 500")
   })
 
-  it("throws a clear error when Apple's backend returns malformed JSON", async () => {
+  it("throws a clear error when the moved endpoint reports the path as gone", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response("", {
+        status: 404,
+        headers: { "Content-Type": "text/plain" },
+      }),
+    )
+
+    await expect(searchAppleDeveloperDocs("anything")).rejects.toThrow("Search request failed: 404")
+  })
+
+  it("throws a clear error when Apple's backend returns malformed JSONL", async () => {
     global.fetch = vi.fn().mockResolvedValue(
       new Response("not json", {
         status: 200,
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/jsonl" },
       }),
     )
 


### PR DESCRIPTION
Fixes #94.

Apple retired `/api/v1/search`; the replacement `/api/v1/query` answers only in JSONL, requires an `includedResponses` field, and tags each result with `metadata.metadataKind` instead of a per-source wrapper key.

This reads both channels Apple's own search page asks for: `quickSearch`, whose results arrive inline, and `search`, which streams the ranked list as diffs against a JSON text buffer. Results are deduplicated by URL, since a page can appear in both.

The MCP tool now reports an upstream failure as an error rather than an empty result set, which read as "no such documentation exists" and invited callers to fall back on their own memory.

Verified against the live endpoint: `sosumi search "WKContentRuleList"` returns 20 results across reference pages and WWDC sessions.