### PR TITLE
Publish ARD capability manifest

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     <meta name="robots" content="index, follow">
 
     <link rel="canonical" href="https://sosumi.ai/">
-    <link rel="ai-catalog" href="/.well-known/ai-catalog.json">
+    <link rel="ai-catalog" href="/.well-known/ai-catalog.json" type="application/ai-catalog+json">
 
     <meta property="og:title" content="sosumi.ai - Apple Docs for LLMs">
     <meta property="og:description"

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
     <meta name="robots" content="index, follow">
 
     <link rel="canonical" href="https://sosumi.ai/">
+    <link rel="ai-catalog" href="/.well-known/ai-catalog.json">
 
     <meta property="og:title" content="sosumi.ai - Apple Docs for LLMs">
     <meta property="og:description"

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
     <meta name="robots" content="index, follow">
 
     <link rel="canonical" href="https://sosumi.ai/">
+    <link rel="ard" href="/.well-known/ard.json" type="application/ai-catalog+json">
     <link rel="ai-catalog" href="/.well-known/ai-catalog.json" type="application/ai-catalog+json">
 
     <meta property="og:title" content="sosumi.ai - Apple Docs for LLMs">

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,3 +8,4 @@ Disallow: /design/human-interface-guidelines
 Disallow: /videos/play/
 
 Sitemap: https://sosumi.ai/sitemap.xml
+Agentmap: https://sosumi.ai/.well-known/ai-catalog.json

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,4 +8,4 @@ Disallow: /design/human-interface-guidelines
 Disallow: /videos/play/
 
 Sitemap: https://sosumi.ai/sitemap.xml
-Agentmap: https://sosumi.ai/.well-known/ai-catalog.json
+Agentmap: https://sosumi.ai/.well-known/ard.json

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { cors } from "hono/cors"
 import { HTTPException } from "hono/http-exception"
 import { trimTrailingSlash } from "hono/trailing-slash"
 import { buildAgentCard } from "./lib/a2a"
-import { buildAiCatalog } from "./lib/ard"
+import { AI_CATALOG_MEDIA_TYPE, buildAiCatalog } from "./lib/ard"
 import {
   decodeExternalTargetPath,
   ExternalAccessError,
@@ -89,7 +89,7 @@ app.use("*", async (c, next) => {
   if (c.req.path === "/") {
     links.unshift(
       '</.well-known/api-catalog>; rel="api-catalog"',
-      '</.well-known/ai-catalog.json>; rel="ai-catalog"; type="application/json"',
+      `</.well-known/ai-catalog.json>; rel="ai-catalog"; type="${AI_CATALOG_MEDIA_TYPE}"`,
       '</.well-known/agent-card.json>; rel="service-desc"; type="application/json"',
       '</.well-known/mcp/server-card.json>; rel="service-desc"; type="application/json"',
       '</SKILL.md>; rel="service-doc"',
@@ -238,7 +238,7 @@ app.get("/.well-known/ai-catalog.json", (c) => {
 
   return c.json(buildAiCatalog(origin), 200, {
     ...discoveryHeaders,
-    "Content-Type": "application/json",
+    "Content-Type": `${AI_CATALOG_MEDIA_TYPE}; charset=utf-8`,
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { HTTPException } from "hono/http-exception"
 import { trimTrailingSlash } from "hono/trailing-slash"
 import { buildAgentCard } from "./lib/a2a"
 import { AI_CATALOG_MEDIA_TYPE, buildAiCatalog } from "./lib/ard"
+import { buildDidDocument, DID_DOCUMENT_MEDIA_TYPE } from "./lib/did"
 import {
   decodeExternalTargetPath,
   ExternalAccessError,
@@ -241,6 +242,13 @@ app.get("/.well-known/ai-catalog.json", (c) => {
     "Content-Type": `${AI_CATALOG_MEDIA_TYPE}; charset=utf-8`,
   })
 })
+
+app.get("/.well-known/did.json", async (c) =>
+  c.json(await buildDidDocument(), 200, {
+    ...discoveryHeaders,
+    "Content-Type": `${DID_DOCUMENT_MEDIA_TYPE}; charset=utf-8`,
+  }),
+)
 
 app.get("/.well-known/api-catalog", (c) => {
   const origin = new URL(c.req.url).origin

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ app.use("*", async (c, next) => {
   if (c.req.path === "/") {
     links.unshift(
       '</.well-known/api-catalog>; rel="api-catalog"',
+      `</.well-known/ard.json>; rel="ard"; type="${AI_CATALOG_MEDIA_TYPE}"`,
       `</.well-known/ai-catalog.json>; rel="ai-catalog"; type="${AI_CATALOG_MEDIA_TYPE}"`,
       '</.well-known/agent-card.json>; rel="service-desc"; type="application/json"',
       '</.well-known/mcp/server-card.json>; rel="service-desc"; type="application/json"',
@@ -234,7 +235,7 @@ app.get("/.well-known/security.txt", (c) => {
   )
 })
 
-app.get("/.well-known/ai-catalog.json", (c) => {
+app.on("GET", ["/.well-known/ard.json", "/.well-known/ai-catalog.json"], (c) => {
   const origin = new URL(c.req.url).origin
 
   return c.json(buildAiCatalog(origin), 200, {
@@ -243,12 +244,19 @@ app.get("/.well-known/ai-catalog.json", (c) => {
   })
 })
 
-app.get("/.well-known/did.json", async (c) =>
-  c.json(await buildDidDocument(), 200, {
+app.get("/.well-known/did.json", async (c) => {
+  const document = await buildDidDocument()
+  if (!document) {
+    return c.json({ error: "DID signing key is unavailable." }, 404, {
+      "Cache-Control": "no-store",
+    })
+  }
+
+  return c.json(document, 200, {
     ...discoveryHeaders,
     "Content-Type": `${DID_DOCUMENT_MEDIA_TYPE}; charset=utf-8`,
-  }),
-)
+  })
+})
 
 app.get("/.well-known/api-catalog", (c) => {
   const origin = new URL(c.req.url).origin

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { cors } from "hono/cors"
 import { HTTPException } from "hono/http-exception"
 import { trimTrailingSlash } from "hono/trailing-slash"
 import { buildAgentCard } from "./lib/a2a"
+import { buildAiCatalog } from "./lib/ard"
 import {
   decodeExternalTargetPath,
   ExternalAccessError,
@@ -88,6 +89,7 @@ app.use("*", async (c, next) => {
   if (c.req.path === "/") {
     links.unshift(
       '</.well-known/api-catalog>; rel="api-catalog"',
+      '</.well-known/ai-catalog.json>; rel="ai-catalog"; type="application/json"',
       '</.well-known/agent-card.json>; rel="service-desc"; type="application/json"',
       '</.well-known/mcp/server-card.json>; rel="service-desc"; type="application/json"',
       '</SKILL.md>; rel="service-doc"',
@@ -229,6 +231,15 @@ app.get("/.well-known/security.txt", (c) => {
       "Content-Type": "text/plain; charset=utf-8",
     },
   )
+})
+
+app.get("/.well-known/ai-catalog.json", (c) => {
+  const origin = new URL(c.req.url).origin
+
+  return c.json(buildAiCatalog(origin), 200, {
+    ...discoveryHeaders,
+    "Content-Type": "application/json",
+  })
 })
 
 app.get("/.well-known/api-catalog", (c) => {

--- a/src/lib/ard.ts
+++ b/src/lib/ard.ts
@@ -1,3 +1,4 @@
+import { PUBLISHER_DID, PUBLISHER_DOMAIN } from "./identity"
 import { SKILL_NAME } from "./skill"
 
 export const AI_CATALOG_MEDIA_TYPE = "application/ai-catalog+json"
@@ -26,13 +27,13 @@ export function buildAiCatalog(origin: string): AiCatalog {
   return {
     specVersion: "1.0",
     host: {
-      displayName: "sosumi.ai",
-      identifier: "did:web:sosumi.ai",
+      displayName: PUBLISHER_DOMAIN,
+      identifier: PUBLISHER_DID,
       documentationUrl: `${origin}/`,
     },
     entries: [
       {
-        identifier: "urn:air:sosumi.ai:server:mcp",
+        identifier: `urn:air:${PUBLISHER_DOMAIN}:server:mcp`,
         displayName: "Sosumi MCP Server",
         type: "application/mcp-server-card+json",
         url: `${origin}/.well-known/mcp/server-card.json`,
@@ -46,7 +47,7 @@ export function buildAiCatalog(origin: string): AiCatalog {
         ],
       },
       {
-        identifier: "urn:air:sosumi.ai:agent:documentation",
+        identifier: `urn:air:${PUBLISHER_DOMAIN}:agent:documentation`,
         displayName: "Sosumi Documentation Agent",
         type: "application/a2a-agent-card+json",
         url: `${origin}/.well-known/agent-card.json`,
@@ -59,7 +60,7 @@ export function buildAiCatalog(origin: string): AiCatalog {
         ],
       },
       {
-        identifier: `urn:air:sosumi.ai:skill:${SKILL_NAME}`,
+        identifier: `urn:air:${PUBLISHER_DOMAIN}:skill:${SKILL_NAME}`,
         displayName: "Sosumi Agent Skill",
         type: 'text/markdown; profile="urn:air:agent-skills"',
         url: `${origin}/.well-known/agent-skills/${SKILL_NAME}/SKILL.md`,

--- a/src/lib/ard.ts
+++ b/src/lib/ard.ts
@@ -47,19 +47,6 @@ export function buildAiCatalog(origin: string): AiCatalog {
         ],
       },
       {
-        identifier: `urn:air:${PUBLISHER_DOMAIN}:agent:documentation`,
-        displayName: "Sosumi Documentation Agent",
-        type: "application/a2a-agent-card+json",
-        url: `${origin}/.well-known/agent-card.json`,
-        description:
-          "An A2A agent for discovering and converting Apple and Swift-DocC documentation into clean Markdown.",
-        representativeQueries: [
-          "Find Apple documentation about Swift actors",
-          "Explain the Human Interface Guidelines for color",
-          "How do I make a custom Swift type conform to Sendable?",
-        ],
-      },
-      {
         identifier: `urn:air:${PUBLISHER_DOMAIN}:skill:${SKILL_NAME}`,
         displayName: "Sosumi Agent Skill",
         type: 'text/markdown; profile="urn:air:agent-skills"',

--- a/src/lib/ard.ts
+++ b/src/lib/ard.ts
@@ -1,3 +1,7 @@
+import { SKILL_NAME } from "./skill"
+
+export const AI_CATALOG_MEDIA_TYPE = "application/ai-catalog+json"
+
 export interface AiCatalogEntry {
   identifier: string
   displayName: string
@@ -55,10 +59,10 @@ export function buildAiCatalog(origin: string): AiCatalog {
         ],
       },
       {
-        identifier: "urn:air:sosumi.ai:skill:sosumi",
+        identifier: `urn:air:sosumi.ai:skill:${SKILL_NAME}`,
         displayName: "Sosumi Agent Skill",
         type: 'text/markdown; profile="urn:air:agent-skills"',
-        url: `${origin}/.well-known/agent-skills/sosumi/SKILL.md`,
+        url: `${origin}/.well-known/agent-skills/${SKILL_NAME}/SKILL.md`,
         description:
           "Instructions for using Sosumi to research Apple APIs, design guidance, videos, and Swift-DocC documentation.",
         representativeQueries: [

--- a/src/lib/ard.ts
+++ b/src/lib/ard.ts
@@ -1,0 +1,72 @@
+export interface AiCatalogEntry {
+  identifier: string
+  displayName: string
+  type: string
+  url: string
+  description: string
+  representativeQueries: string[]
+}
+
+export interface AiCatalog {
+  specVersion: string
+  host: {
+    displayName: string
+    identifier: string
+    documentationUrl: string
+  }
+  entries: AiCatalogEntry[]
+}
+
+/** Build the ARD capability manifest for the origin serving the request. */
+export function buildAiCatalog(origin: string): AiCatalog {
+  return {
+    specVersion: "1.0",
+    host: {
+      displayName: "sosumi.ai",
+      identifier: "did:web:sosumi.ai",
+      documentationUrl: `${origin}/`,
+    },
+    entries: [
+      {
+        identifier: "urn:air:sosumi.ai:server:mcp",
+        displayName: "Sosumi MCP Server",
+        type: "application/mcp-server-card+json",
+        url: `${origin}/.well-known/mcp/server-card.json`,
+        description:
+          "Searches and fetches Apple Developer documentation, Human Interface Guidelines, WWDC transcripts, and public Swift-DocC pages.",
+        representativeQueries: [
+          "Search Apple Developer documentation for URLSession",
+          "Fetch the SwiftUI View documentation as Markdown",
+          "Get the transcript for a WWDC session",
+          "Read a public Swift-DocC documentation page",
+        ],
+      },
+      {
+        identifier: "urn:air:sosumi.ai:agent:documentation",
+        displayName: "Sosumi Documentation Agent",
+        type: "application/a2a-agent-card+json",
+        url: `${origin}/.well-known/agent-card.json`,
+        description:
+          "An A2A agent for discovering and converting Apple and Swift-DocC documentation into clean Markdown.",
+        representativeQueries: [
+          "Find Apple documentation about Swift actors",
+          "Explain the Human Interface Guidelines for color",
+          "How do I make a custom Swift type conform to Sendable?",
+        ],
+      },
+      {
+        identifier: "urn:air:sosumi.ai:skill:sosumi",
+        displayName: "Sosumi Agent Skill",
+        type: 'text/markdown; profile="urn:air:agent-skills"',
+        url: `${origin}/.well-known/agent-skills/sosumi/SKILL.md`,
+        description:
+          "Instructions for using Sosumi to research Apple APIs, design guidance, videos, and Swift-DocC documentation.",
+        representativeQueries: [
+          "Research an Apple framework API before writing code",
+          "Look up current SwiftUI documentation",
+          "Find Apple's design guidance for an interface",
+        ],
+      },
+    ],
+  }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,105 @@
+import { jwkToKeyID, type Signer } from "web-bot-auth"
+import { helpers, signerFromJWK } from "web-bot-auth/crypto"
+
+/** The public half of the application's Ed25519 signing key. */
+export interface PublicSigningKey {
+  kty: "OKP"
+  crv: "Ed25519"
+  x: string
+  kid: string
+  use: string
+}
+
+export interface SigningKeyConfig {
+  signer: Signer
+  publicKey: PublicSigningKey
+}
+
+interface Ed25519PrivateJwk {
+  kty: "OKP"
+  crv: "Ed25519"
+  x: string
+  d: string
+}
+
+let cache: { key: string; config: Promise<SigningKeyConfig> } | null = null
+
+/** Configure the application-wide signing key from a serialized private JWK. */
+export function configureSigningKey(serializedKey?: string): void {
+  const key = serializedKey?.trim()
+  if (!key) {
+    cache = null
+    return
+  }
+
+  if (cache?.key === key) {
+    return
+  }
+
+  cache = { key, config: buildSigningKeyConfig(key) }
+}
+
+/** Return the configured signer and public key, or null if unavailable. */
+export async function currentSigningKey(): Promise<SigningKeyConfig | null> {
+  const entry = cache
+  if (!entry) {
+    return null
+  }
+
+  try {
+    return await entry.config
+  } catch (error) {
+    console.error("auth: failed to load signing key", error)
+    if (cache === entry) {
+      cache = null
+    }
+    return null
+  }
+}
+
+/** Return a copy of the configured public signing key, if available. */
+export async function currentPublicSigningKey(): Promise<PublicSigningKey | null> {
+  const config = await currentSigningKey()
+  return config ? { ...config.publicKey } : null
+}
+
+function parseSigningJwk(key: string): Ed25519PrivateJwk {
+  let jwk: JsonWebKey
+  try {
+    jwk = JSON.parse(key) as JsonWebKey
+  } catch (error) {
+    throw new Error(`WEB_BOT_AUTH_KEY is not valid JSON: ${(error as Error).message}`)
+  }
+
+  if (
+    jwk.kty !== "OKP" ||
+    jwk.crv !== "Ed25519" ||
+    typeof jwk.x !== "string" ||
+    jwk.x.length === 0 ||
+    typeof jwk.d !== "string" ||
+    jwk.d.length === 0
+  ) {
+    throw new Error(
+      "WEB_BOT_AUTH_KEY must be an Ed25519 private JSON Web Key (kty=OKP, crv=Ed25519, with x and d).",
+    )
+  }
+
+  return { kty: jwk.kty, crv: jwk.crv, x: jwk.x, d: jwk.d }
+}
+
+async function buildSigningKeyConfig(key: string): Promise<SigningKeyConfig> {
+  const jwk = parseSigningJwk(key)
+  const signer = await signerFromJWK(jwk)
+  const kid = await jwkToKeyID(jwk, helpers.WEBCRYPTO_SHA256, helpers.BASE64URL_DECODE)
+
+  return {
+    signer,
+    publicKey: {
+      kty: jwk.kty,
+      crv: jwk.crv,
+      x: jwk.x,
+      kid,
+      use: "sig",
+    },
+  }
+}

--- a/src/lib/did.ts
+++ b/src/lib/did.ts
@@ -1,15 +1,15 @@
+import { currentPublicSigningKey } from "./auth"
 import { PUBLISHER_DID, PUBLISHER_ORIGIN } from "./identity"
-import { webBotAuthPublicKey } from "./webbotauth"
 
 export const DID_DOCUMENT_MEDIA_TYPE = "application/did+ld+json"
 
 /**
  * Build the did:web document for Sosumi's stable publisher identity.
- * The verification method reuses the public half of the Web Bot Auth
- * signing key, which is configured out of band and never committed.
+ * The verification method reuses the public half of the application signing
+ * key, which is configured out of band and never committed.
  */
 export async function buildDidDocument() {
-  const publicKey = await webBotAuthPublicKey()
+  const publicKey = await currentPublicSigningKey()
   const document = {
     "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/suites/jws-2020/v1"],
     id: PUBLISHER_DID,

--- a/src/lib/did.ts
+++ b/src/lib/did.ts
@@ -6,24 +6,21 @@ export const DID_DOCUMENT_MEDIA_TYPE = "application/did+ld+json"
 /**
  * Build the did:web document for Sosumi's stable publisher identity.
  * The verification method reuses the public half of the application signing
- * key, which is configured out of band and never committed.
+ * key, which is configured out of band and never committed. Returns `null`
+ * rather than publishing an unverifiable identity when that key is unavailable.
  */
 export async function buildDidDocument() {
   const publicKey = await currentPublicSigningKey()
-  const document = {
-    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/suites/jws-2020/v1"],
-    id: PUBLISHER_DID,
-    alsoKnownAs: [PUBLISHER_ORIGIN],
-  }
-
   if (!publicKey) {
-    return document
+    return null
   }
 
   const verificationMethodId = `${PUBLISHER_DID}#${publicKey.kid}`
 
   return {
-    ...document,
+    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/suites/jws-2020/v1"],
+    id: PUBLISHER_DID,
+    alsoKnownAs: [PUBLISHER_ORIGIN],
     verificationMethod: [
       {
         id: verificationMethodId,

--- a/src/lib/did.ts
+++ b/src/lib/did.ts
@@ -1,0 +1,43 @@
+import { PUBLISHER_DID, PUBLISHER_ORIGIN } from "./identity"
+import { webBotAuthPublicKey } from "./webbotauth"
+
+export const DID_DOCUMENT_MEDIA_TYPE = "application/did+ld+json"
+
+/**
+ * Build the did:web document for Sosumi's stable publisher identity.
+ * The verification method reuses the public half of the Web Bot Auth
+ * signing key, which is configured out of band and never committed.
+ */
+export async function buildDidDocument() {
+  const publicKey = await webBotAuthPublicKey()
+  const document = {
+    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/suites/jws-2020/v1"],
+    id: PUBLISHER_DID,
+    alsoKnownAs: [PUBLISHER_ORIGIN],
+  }
+
+  if (!publicKey) {
+    return document
+  }
+
+  const verificationMethodId = `${PUBLISHER_DID}#${publicKey.kid}`
+
+  return {
+    ...document,
+    verificationMethod: [
+      {
+        id: verificationMethodId,
+        type: "JsonWebKey2020",
+        controller: PUBLISHER_DID,
+        publicKeyJwk: {
+          kty: publicKey.kty,
+          crv: publicKey.crv,
+          x: publicKey.x,
+          kid: publicKey.kid,
+        },
+      },
+    ],
+    authentication: [verificationMethodId],
+    assertionMethod: [verificationMethodId],
+  }
+}

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -1,0 +1,6 @@
+import { MCP_SERVER_INFO } from "./mcp"
+
+/** Stable publisher identity, intentionally independent of the request origin. */
+export const PUBLISHER_DOMAIN = MCP_SERVER_INFO.name
+export const PUBLISHER_DID = `did:web:${PUBLISHER_DOMAIN}`
+export const PUBLISHER_ORIGIN = `https://${PUBLISHER_DOMAIN}`

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -1,6 +1,4 @@
-import { MCP_SERVER_INFO } from "./mcp"
-
 /** Stable publisher identity, intentionally independent of the request origin. */
-export const PUBLISHER_DOMAIN = MCP_SERVER_INFO.name
+export const PUBLISHER_DOMAIN = "sosumi.ai"
 export const PUBLISHER_DID = `did:web:${PUBLISHER_DOMAIN}`
 export const PUBLISHER_ORIGIN = `https://${PUBLISHER_DOMAIN}`

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -4,13 +4,14 @@ import { z } from "zod"
 import type { ExternalPolicyEnv } from "./external"
 import { fetchExternalDocumentationMarkdown } from "./external"
 import { fetchHIGPageData, renderHIGFromJSON } from "./hig"
+import { PUBLISHER_DOMAIN } from "./identity"
 import { fetchJSONData, renderFromJSON } from "./reference"
 import { searchAppleDeveloperDocs } from "./search"
 import { generateAppleDocUrl, normalizeDocumentationPath } from "./url"
 import { fetchVideoTranscriptMarkdown } from "./video"
 
 export const MCP_SERVER_INFO = {
-  name: "sosumi.ai",
+  name: PUBLISHER_DOMAIN,
   version: "1.0.0",
 } as const
 

--- a/src/lib/webbotauth.ts
+++ b/src/lib/webbotauth.ts
@@ -28,6 +28,7 @@ import {
   signatureHeaders,
 } from "web-bot-auth"
 import { helpers, signerFromJWK } from "web-bot-auth/crypto"
+import { PUBLISHER_ORIGIN } from "./identity"
 
 export interface WebBotAuthEnv {
   /**
@@ -45,7 +46,7 @@ export const DIRECTORY_PATH = HTTP_MESSAGE_SIGNATURES_DIRECTORY
 /** Content type for the key directory response. */
 export const DIRECTORY_MEDIA_TYPE = MediaType.HTTP_MESSAGE_SIGNATURES_DIRECTORY
 
-const DEFAULT_SIGNATURE_AGENT = "https://sosumi.ai"
+const DEFAULT_SIGNATURE_AGENT = PUBLISHER_ORIGIN
 
 /**
  * How long an outbound request signature stays valid.

--- a/src/lib/webbotauth.ts
+++ b/src/lib/webbotauth.ts
@@ -58,9 +58,9 @@ const DIRECTORY_SIGNATURE_TTL_MS = 60 * 60 * 1000
 
 /** A public JSON Web Key as published in the directory (RFC 8037 Ed25519). */
 export interface DirectoryKey {
-  kty?: string
-  crv?: string
-  x?: string
+  kty: "OKP"
+  crv: "Ed25519"
+  x: string
   kid: string
   use: string
 }
@@ -171,6 +171,12 @@ async function currentConfig(): Promise<WebBotAuthConfig | null> {
     }
     return null
   }
+}
+
+/** Return a copy of the configured public signing key, if available. */
+export async function webBotAuthPublicKey(): Promise<DirectoryKey | null> {
+  const config = await currentConfig()
+  return config ? { ...config.publicKey } : null
 }
 
 /** Serialize a value as an RFC 8941 structured-field string (a quoted string). */

--- a/src/lib/webbotauth.ts
+++ b/src/lib/webbotauth.ts
@@ -22,12 +22,10 @@
 import {
   directoryResponseHeaders,
   HTTP_MESSAGE_SIGNATURES_DIRECTORY,
-  jwkToKeyID,
   MediaType,
-  type Signer,
   signatureHeaders,
 } from "web-bot-auth"
-import { helpers, signerFromJWK } from "web-bot-auth/crypto"
+import { configureSigningKey, currentSigningKey, type PublicSigningKey } from "./auth"
 import { PUBLISHER_ORIGIN } from "./identity"
 
 export interface WebBotAuthEnv {
@@ -57,28 +55,7 @@ const OUTBOUND_SIGNATURE_TTL_MS = 5 * 60 * 1000
 /** How long the directory self-signature stays valid. */
 const DIRECTORY_SIGNATURE_TTL_MS = 60 * 60 * 1000
 
-/** A public JSON Web Key as published in the directory (RFC 8037 Ed25519). */
-export interface DirectoryKey {
-  kty: "OKP"
-  crv: "Ed25519"
-  x: string
-  kid: string
-  use: string
-}
-
-interface WebBotAuthConfig {
-  signer: Signer
-  publicKey: DirectoryKey
-  agent: string
-}
-
-/**
- * Cached, parsed configuration.
- * The signing key is application-global (the same for every request),
- * so it is memoized across requests in the isolate
- * and only rebuilt when the underlying secret or agent changes.
- */
-let cache: { key: string; agent: string; config: Promise<WebBotAuthConfig> } | null = null
+let signatureAgent: string | null = null
 
 /**
  * Prime the signing configuration from the environment.
@@ -87,97 +64,8 @@ let cache: { key: string; agent: string; config: Promise<WebBotAuthConfig> } | n
  */
 export function configureWebBotAuth(env: WebBotAuthEnv): void {
   const key = env.WEB_BOT_AUTH_KEY?.trim()
-  if (!key) {
-    cache = null
-    return
-  }
-
-  const agent = env.SIGNATURE_AGENT?.trim() || DEFAULT_SIGNATURE_AGENT
-  if (cache && cache.key === key && cache.agent === agent) {
-    return
-  }
-
-  cache = { key, agent, config: buildConfig(key, agent) }
-}
-
-interface Ed25519PrivateJwk {
-  kty: "OKP"
-  crv: "Ed25519"
-  x: string
-  d: string
-}
-
-/**
- * Parse and validate the signing secret as an Ed25519 OKP private JWK.
- * Fails closed on anything malformed
- * so a misconfigured `WEB_BOT_AUTH_KEY` never yields a broken directory key
- * or unverifiable signatures.
- */
-function parseSigningJwk(key: string): Ed25519PrivateJwk {
-  let jwk: JsonWebKey
-  try {
-    jwk = JSON.parse(key) as JsonWebKey
-  } catch (error) {
-    throw new Error(`WEB_BOT_AUTH_KEY is not valid JSON: ${(error as Error).message}`)
-  }
-
-  if (
-    jwk.kty !== "OKP" ||
-    jwk.crv !== "Ed25519" ||
-    typeof jwk.x !== "string" ||
-    jwk.x.length === 0 ||
-    typeof jwk.d !== "string" ||
-    jwk.d.length === 0
-  ) {
-    throw new Error(
-      "WEB_BOT_AUTH_KEY must be an Ed25519 private JSON Web Key (kty=OKP, crv=Ed25519, with x and d).",
-    )
-  }
-
-  return { kty: jwk.kty, crv: jwk.crv, x: jwk.x, d: jwk.d }
-}
-
-async function buildConfig(key: string, agent: string): Promise<WebBotAuthConfig> {
-  const jwk = parseSigningJwk(key)
-  const signer = await signerFromJWK(jwk)
-  const kid = await jwkToKeyID(jwk, helpers.WEBCRYPTO_SHA256, helpers.BASE64URL_DECODE)
-
-  // Publish only the public half of the key (never the `d` parameter).
-  const publicKey: DirectoryKey = {
-    kty: jwk.kty,
-    crv: jwk.crv,
-    x: jwk.x,
-    kid,
-    use: "sig",
-  }
-
-  return { signer, publicKey, agent }
-}
-
-async function currentConfig(): Promise<WebBotAuthConfig | null> {
-  const entry = cache
-  if (!entry) {
-    return null
-  }
-
-  try {
-    return await entry.config
-  } catch (error) {
-    console.error("web-bot-auth: failed to load signing key", error)
-    // Drop the failed config so the next request rebuilds it,
-    // rather than serving the cached rejection until the isolate restarts.
-    // Guard against clobbering a newer config set by a concurrent reconfigure.
-    if (cache === entry) {
-      cache = null
-    }
-    return null
-  }
-}
-
-/** Return a copy of the configured public signing key, if available. */
-export async function webBotAuthPublicKey(): Promise<DirectoryKey | null> {
-  const config = await currentConfig()
-  return config ? { ...config.publicKey } : null
+  configureSigningKey(key)
+  signatureAgent = key ? env.SIGNATURE_AGENT?.trim() || DEFAULT_SIGNATURE_AGENT : null
 }
 
 /** Serialize a value as an RFC 8941 structured-field string (a quoted string). */
@@ -186,7 +74,7 @@ function structuredString(value: string): string {
 }
 
 export interface DirectoryResponse {
-  body: { keys: DirectoryKey[] }
+  body: { keys: PublicSigningKey[] }
   headers: Record<string, string>
 }
 
@@ -200,8 +88,8 @@ export interface DirectoryResponse {
  * demonstrating control of the published key.
  */
 export async function webBotAuthDirectory(requestUrl: string): Promise<DirectoryResponse | null> {
-  const config = await currentConfig()
-  if (!config) {
+  const signingKey = await currentSigningKey()
+  if (!signingKey) {
     return null
   }
 
@@ -212,10 +100,13 @@ export async function webBotAuthDirectory(requestUrl: string): Promise<Directory
     request: { method: "GET", url: requestUrl, headers: {} as Record<string, string> },
   }
 
-  const signature = await directoryResponseHeaders(message, [config.signer], { created, expires })
+  const signature = await directoryResponseHeaders(message, [signingKey.signer], {
+    created,
+    expires,
+  })
 
   return {
-    body: { keys: [config.publicKey] },
+    body: { keys: [signingKey.publicKey] },
     headers: {
       "Content-Type": DIRECTORY_MEDIA_TYPE,
       Signature: signature.Signature,
@@ -235,13 +126,14 @@ export async function webBotAuthHeaders(
   method: string,
   url: string | URL,
 ): Promise<Record<string, string>> {
-  const config = await currentConfig()
-  if (!config) {
+  const signingKey = await currentSigningKey()
+  const agentValue = signatureAgent
+  if (!signingKey || !agentValue) {
     return {}
   }
 
   try {
-    const agent = structuredString(config.agent)
+    const agent = structuredString(agentValue)
     // `signature-agent` must be present on the message
     // so it is covered by the signature;
     // the same value is returned for the outbound request.
@@ -252,7 +144,7 @@ export async function webBotAuthHeaders(
     const expires = new Date(created.getTime() + OUTBOUND_SIGNATURE_TTL_MS)
     const signature = await signatureHeaders(
       { method, url: url.toString(), headers },
-      config.signer,
+      signingKey.signer,
       { created, expires },
     )
 

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -1,5 +1,5 @@
 import { env, SELF } from "cloudflare:test"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import app from "../src/index"
 import { buildAiCatalog } from "../src/lib/ard"
 import { PUBLISHER_DID, PUBLISHER_DOMAIN, PUBLISHER_ORIGIN } from "../src/lib/identity"
@@ -29,7 +29,7 @@ describe("Agent discovery endpoints", () => {
   })
 
   it("serves an ARD capability manifest", async () => {
-    const response = await SELF.fetch("https://sosumi.ai/.well-known/ai-catalog.json")
+    const response = await SELF.fetch("https://sosumi.ai/.well-known/ard.json")
 
     expect(response.status).toBe(200)
     expect(response.headers.get("Content-Type")).toContain("application/ai-catalog+json")
@@ -79,6 +79,16 @@ describe("Agent discovery endpoints", () => {
       identifier: `urn:air:${PUBLISHER_DOMAIN}:skill:${SKILL_NAME}`,
       url: `${PUBLISHER_ORIGIN}/.well-known/agent-skills/${SKILL_NAME}/SKILL.md`,
     })
+  })
+
+  it("keeps the predecessor AI catalog path as an alias", async () => {
+    const [ardResponse, legacyResponse] = await Promise.all([
+      SELF.fetch("https://sosumi.ai/.well-known/ard.json"),
+      SELF.fetch("https://sosumi.ai/.well-known/ai-catalog.json"),
+    ])
+
+    expect(legacyResponse.status).toBe(200)
+    expect(await legacyResponse.json()).toEqual(await ardResponse.json())
   })
 
   it("keeps publisher identity stable across catalog locations", () => {
@@ -137,6 +147,31 @@ describe("Agent discovery endpoints", () => {
     expect(verificationMethod.publicKeyJwk).not.toHaveProperty("d")
     expect(did.authentication).toContain(verificationMethod.id)
     expect(did.assertionMethod).toContain(verificationMethod.id)
+  })
+
+  it("does not publish a DID document without a valid signing key", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    try {
+      const bindings = {
+        ASSETS: env.ASSETS,
+        NODE_ENV: "production",
+      }
+      const [missingKeyResponse, invalidKeyResponse] = await Promise.all([
+        app.request(`${PUBLISHER_ORIGIN}/.well-known/did.json`, undefined, bindings),
+        app.request(`${PUBLISHER_ORIGIN}/.well-known/did.json`, undefined, {
+          ...bindings,
+          WEB_BOT_AUTH_KEY: "not-json",
+        }),
+      ])
+
+      expect(missingKeyResponse.status).toBe(404)
+      expect(invalidKeyResponse.status).toBe(404)
+      expect(missingKeyResponse.headers.get("Cache-Control")).toBe("no-store")
+      expect(invalidKeyResponse.headers.get("Cache-Control")).toBe("no-store")
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 
   it("serves an RFC 9727 API catalog", async () => {
@@ -230,6 +265,7 @@ describe("Agent discovery endpoints", () => {
     const link = response.headers.get("Link")
     expect(link).toContain('rel="api-catalog"')
     expect(link).toContain("/.well-known/api-catalog")
+    expect(link).toContain('</.well-known/ard.json>; rel="ard"')
     expect(link).toContain("/.well-known/ai-catalog.json")
     expect(link).toContain("/.well-known/agent-card.json")
     expect(link).toContain('</llms.txt>; rel="alternate"; type="text/markdown"')
@@ -287,11 +323,11 @@ describe("Agent discovery endpoints", () => {
       env.ASSETS.fetch(new Request("https://sosumi.ai/robots.txt")),
     ])
 
-    expect(await homepageResponse.text()).toContain(
-      '<link rel="ai-catalog" href="/.well-known/ai-catalog.json" type="application/ai-catalog+json">',
-    )
+    const homepage = await homepageResponse.text()
+    expect(homepage).toContain('<link rel="ard" href="/.well-known/ard.json"')
+    expect(homepage).toContain('<link rel="ai-catalog" href="/.well-known/ai-catalog.json"')
     expect(await robotsResponse.text()).toContain(
-      "Agentmap: https://sosumi.ai/.well-known/ai-catalog.json",
+      "Agentmap: https://sosumi.ai/.well-known/ard.json",
     )
   })
 })

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -1,6 +1,7 @@
 import { env, SELF } from "cloudflare:test"
 import { describe, expect, it } from "vitest"
 import app from "../src/index"
+import { SKILL_NAME } from "../src/lib/skill"
 
 describe("Agent discovery endpoints", () => {
   it("serves a security.txt file with a rolling expiry", async () => {
@@ -29,7 +30,7 @@ describe("Agent discovery endpoints", () => {
     const response = await SELF.fetch("https://sosumi.ai/.well-known/ai-catalog.json")
 
     expect(response.status).toBe(200)
-    expect(response.headers.get("Content-Type")).toBe("application/json")
+    expect(response.headers.get("Content-Type")).toContain("application/ai-catalog+json")
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*")
 
     const catalog = (await response.json()) as {
@@ -68,6 +69,12 @@ describe("Agent discovery endpoints", () => {
       "application/a2a-agent-card+json",
       'text/markdown; profile="urn:air:agent-skills"',
     ])
+
+    const skillEntry = catalog.entries.find((entry) => entry.type.startsWith("text/markdown"))
+    expect(skillEntry).toMatchObject({
+      identifier: `urn:air:sosumi.ai:skill:${SKILL_NAME}`,
+      url: `https://sosumi.ai/.well-known/agent-skills/${SKILL_NAME}/SKILL.md`,
+    })
   })
 
   it("serves an RFC 9727 API catalog", async () => {
@@ -219,7 +226,7 @@ describe("Agent discovery endpoints", () => {
     ])
 
     expect(await homepageResponse.text()).toContain(
-      '<link rel="ai-catalog" href="/.well-known/ai-catalog.json">',
+      '<link rel="ai-catalog" href="/.well-known/ai-catalog.json" type="application/ai-catalog+json">',
     )
     expect(await robotsResponse.text()).toContain(
       "Agentmap: https://sosumi.ai/.well-known/ai-catalog.json",

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -1,6 +1,8 @@
 import { env, SELF } from "cloudflare:test"
 import { describe, expect, it } from "vitest"
 import app from "../src/index"
+import { buildAiCatalog } from "../src/lib/ard"
+import { PUBLISHER_DID, PUBLISHER_DOMAIN, PUBLISHER_ORIGIN } from "../src/lib/identity"
 import { SKILL_NAME } from "../src/lib/skill"
 
 describe("Agent discovery endpoints", () => {
@@ -49,14 +51,16 @@ describe("Agent discovery endpoints", () => {
     expect(catalog.specVersion).toBeTruthy()
     expect(catalog.host).toEqual(
       expect.objectContaining({
-        displayName: "sosumi.ai",
-        identifier: "did:web:sosumi.ai",
+        displayName: PUBLISHER_DOMAIN,
+        identifier: PUBLISHER_DID,
       }),
     )
     expect(catalog.entries).toHaveLength(3)
 
     for (const entry of catalog.entries) {
-      expect(entry.identifier).toMatch(/^urn:air:sosumi\.ai:[a-z0-9-]+:[a-z0-9-]+$/)
+      expect(entry.identifier).toMatch(
+        new RegExp(`^urn:air:${PUBLISHER_DOMAIN.replaceAll(".", "\\.")}:[a-z0-9-]+:[a-z0-9-]+$`),
+      )
       expect(entry.displayName).toBeTruthy()
       expect(entry.type).toMatch(/^[a-z]+\/[a-z0-9.+-]+(?:; .+)?$/i)
       expect(Number("url" in entry) + Number("data" in entry)).toBe(1)
@@ -72,9 +76,67 @@ describe("Agent discovery endpoints", () => {
 
     const skillEntry = catalog.entries.find((entry) => entry.type.startsWith("text/markdown"))
     expect(skillEntry).toMatchObject({
-      identifier: `urn:air:sosumi.ai:skill:${SKILL_NAME}`,
-      url: `https://sosumi.ai/.well-known/agent-skills/${SKILL_NAME}/SKILL.md`,
+      identifier: `urn:air:${PUBLISHER_DOMAIN}:skill:${SKILL_NAME}`,
+      url: `${PUBLISHER_ORIGIN}/.well-known/agent-skills/${SKILL_NAME}/SKILL.md`,
     })
+  })
+
+  it("keeps publisher identity stable across catalog locations", () => {
+    const catalog = buildAiCatalog("https://preview.example.com")
+
+    expect(catalog.host.identifier).toBe(PUBLISHER_DID)
+    for (const entry of catalog.entries) {
+      expect(entry.identifier.startsWith(`urn:air:${PUBLISHER_DOMAIN}:`)).toBe(true)
+      expect(entry.url).toMatch(/^https:\/\/preview\.example\.com\//)
+    }
+  })
+
+  it("serves a verifiable did:web document", async () => {
+    const [didResponse, directoryResponse] = await Promise.all([
+      SELF.fetch(`${PUBLISHER_ORIGIN}/.well-known/did.json`),
+      SELF.fetch(`${PUBLISHER_ORIGIN}/.well-known/http-message-signatures-directory`),
+    ])
+
+    expect(didResponse.status).toBe(200)
+    expect(didResponse.headers.get("Content-Type")).toContain("application/did+ld+json")
+    expect(didResponse.headers.get("Access-Control-Allow-Origin")).toBe("*")
+
+    const did = (await didResponse.json()) as {
+      "@context": string[]
+      id: string
+      alsoKnownAs: string[]
+      verificationMethod: Array<{
+        id: string
+        type: string
+        controller: string
+        publicKeyJwk: Record<string, string>
+      }>
+      authentication: string[]
+      assertionMethod: string[]
+    }
+    const directory = (await directoryResponse.json()) as {
+      keys: Array<Record<string, string>>
+    }
+    const verificationMethod = did.verificationMethod[0]
+    const publishedKey = directory.keys[0]
+
+    expect(did["@context"]).toContain("https://www.w3.org/ns/did/v1")
+    expect(did.id).toBe(PUBLISHER_DID)
+    expect(did.alsoKnownAs).toContain(PUBLISHER_ORIGIN)
+    expect(verificationMethod).toMatchObject({
+      id: `${PUBLISHER_DID}#${publishedKey.kid}`,
+      type: "JsonWebKey2020",
+      controller: PUBLISHER_DID,
+      publicKeyJwk: {
+        kty: publishedKey.kty,
+        crv: publishedKey.crv,
+        x: publishedKey.x,
+        kid: publishedKey.kid,
+      },
+    })
+    expect(verificationMethod.publicKeyJwk).not.toHaveProperty("d")
+    expect(did.authentication).toContain(verificationMethod.id)
+    expect(did.assertionMethod).toContain(verificationMethod.id)
   })
 
   it("serves an RFC 9727 API catalog", async () => {

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -25,6 +25,51 @@ describe("Agent discovery endpoints", () => {
     expect(expiresAt).toBeLessThan(requestedAt + 365 * 24 * 60 * 60 * 1000)
   })
 
+  it("serves an ARD capability manifest", async () => {
+    const response = await SELF.fetch("https://sosumi.ai/.well-known/ai-catalog.json")
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Content-Type")).toBe("application/json")
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*")
+
+    const catalog = (await response.json()) as {
+      specVersion: string
+      host: { displayName: string; identifier: string }
+      entries: Array<{
+        identifier: string
+        displayName: string
+        type: string
+        url?: string
+        data?: unknown
+        representativeQueries: string[]
+      }>
+    }
+
+    expect(catalog.specVersion).toBeTruthy()
+    expect(catalog.host).toEqual(
+      expect.objectContaining({
+        displayName: "sosumi.ai",
+        identifier: "did:web:sosumi.ai",
+      }),
+    )
+    expect(catalog.entries).toHaveLength(3)
+
+    for (const entry of catalog.entries) {
+      expect(entry.identifier).toMatch(/^urn:air:sosumi\.ai:[a-z0-9-]+:[a-z0-9-]+$/)
+      expect(entry.displayName).toBeTruthy()
+      expect(entry.type).toMatch(/^[a-z]+\/[a-z0-9.+-]+(?:; .+)?$/i)
+      expect(Number("url" in entry) + Number("data" in entry)).toBe(1)
+      expect(entry.representativeQueries.length).toBeGreaterThanOrEqual(2)
+      expect(entry.representativeQueries.length).toBeLessThanOrEqual(5)
+    }
+
+    expect(catalog.entries.map((entry) => entry.type)).toEqual([
+      "application/mcp-server-card+json",
+      "application/a2a-agent-card+json",
+      'text/markdown; profile="urn:air:agent-skills"',
+    ])
+  })
+
   it("serves an RFC 9727 API catalog", async () => {
     const response = await SELF.fetch("https://sosumi.ai/.well-known/api-catalog")
 
@@ -116,6 +161,7 @@ describe("Agent discovery endpoints", () => {
     const link = response.headers.get("Link")
     expect(link).toContain('rel="api-catalog"')
     expect(link).toContain("/.well-known/api-catalog")
+    expect(link).toContain("/.well-known/ai-catalog.json")
     expect(link).toContain("/.well-known/agent-card.json")
     expect(link).toContain('</llms.txt>; rel="alternate"; type="text/markdown"')
     expect(link).toContain('</llms.txt>; rel="describedby"')
@@ -164,5 +210,19 @@ describe("Agent discovery endpoints", () => {
     const robots = await response.text()
     expect(robots).toContain("Content-Signal: search=yes, ai-input=yes, ai-train=no")
     expect(robots).toContain("Content-Usage: train-ai=n, search=y")
+  })
+
+  it("advertises the ARD manifest in HTML and robots.txt", async () => {
+    const [homepageResponse, robotsResponse] = await Promise.all([
+      SELF.fetch("https://sosumi.ai/"),
+      env.ASSETS.fetch(new Request("https://sosumi.ai/robots.txt")),
+    ])
+
+    expect(await homepageResponse.text()).toContain(
+      '<link rel="ai-catalog" href="/.well-known/ai-catalog.json">',
+    )
+    expect(await robotsResponse.text()).toContain(
+      "Agentmap: https://sosumi.ai/.well-known/ai-catalog.json",
+    )
   })
 })

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -55,7 +55,7 @@ describe("Agent discovery endpoints", () => {
         identifier: PUBLISHER_DID,
       }),
     )
-    expect(catalog.entries).toHaveLength(3)
+    expect(catalog.entries).toHaveLength(2)
 
     for (const entry of catalog.entries) {
       expect(entry.identifier).toMatch(
@@ -70,7 +70,6 @@ describe("Agent discovery endpoints", () => {
 
     expect(catalog.entries.map((entry) => entry.type)).toEqual([
       "application/mcp-server-card+json",
-      "application/a2a-agent-card+json",
       'text/markdown; profile="urn:air:agent-skills"',
     ])
 


### PR DESCRIPTION
## Summary

- Publishes `/.well-known/ard.json` with MCP server and agent skill entries while retaining `/.well-known/ai-catalog.json` as a compatibility alias.
- Keeps publisher identity stable across catalog locations.
- Adds HTTP, HTML, and `robots.txt` discovery hints.
- Covers manifest structure, discovery headers, stable identifiers, DID verification material, and representative queries.

Along the way, we also added a verifiable `did:web:sosumi.ai` document backed by the existing Web Bot Auth signing key.

## Testing

- `npm run test:run`
- `npm run check:ci`