### PR TITLE
Add llms.txt v2 discovery links

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,16 @@ interface Env {
 
 const app = new Hono<{ Bindings: Env }>()
 
+function isMarkdownContentRoute(path: string): boolean {
+  return (
+    path.startsWith("/documentation/") ||
+    path.startsWith("/external/") ||
+    path === "/design/human-interface-guidelines" ||
+    path.startsWith("/design/human-interface-guidelines/") ||
+    path.startsWith("/videos/play/")
+  )
+}
+
 app.use("*", async (c, next) => {
   // Prime Web Bot Auth signing before any route or outbound fetch runs.
   configureWebBotAuth(c.env)
@@ -72,18 +82,23 @@ app.use("*", async (c, next) => {
     c.header("Cache-Control", "no-store")
   }
 
+  const links = ['</llms.txt>; rel="describedby"']
+
   if (c.req.path === "/") {
-    c.header(
-      "Link",
-      [
-        '</.well-known/api-catalog>; rel="api-catalog"',
-        '</.well-known/agent-card.json>; rel="service-desc"; type="application/json"',
-        '</.well-known/mcp/server-card.json>; rel="service-desc"; type="application/json"',
-        '</SKILL.md>; rel="service-doc"',
-        '</llms.txt>; rel="alternate"; type="text/markdown"',
-      ].join(", "),
+    links.unshift(
+      '</.well-known/api-catalog>; rel="api-catalog"',
+      '</.well-known/agent-card.json>; rel="service-desc"; type="application/json"',
+      '</.well-known/mcp/server-card.json>; rel="service-desc"; type="application/json"',
+      '</SKILL.md>; rel="service-doc"',
+      '</llms.txt>; rel="alternate"; type="text/markdown"',
     )
   }
+
+  if (isMarkdownContentRoute(c.req.path)) {
+    links.push(`<${c.req.path}>; rel="alternate"; type="text/markdown"`)
+  }
+
+  c.header("Link", links.join(", "))
 })
 
 app.use("*", cors())

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,11 @@ app.use("*", async (c, next) => {
     links.push(`<${c.req.path}>; rel="alternate"; type="text/markdown"`)
   }
 
+  const existingLink = c.res.headers.get("Link")
+  if (existingLink) {
+    links.unshift(existingLink)
+  }
+
   c.header("Link", links.join(", "))
 })
 

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -93,5 +93,25 @@ describe("Agent discovery endpoints", () => {
     expect(link).toContain('rel="api-catalog"')
     expect(link).toContain("/.well-known/api-catalog")
     expect(link).toContain("/.well-known/agent-card.json")
+    expect(link).toContain('</llms.txt>; rel="alternate"; type="text/markdown"')
+    expect(link).toContain('</llms.txt>; rel="describedby"')
+  })
+
+  it("describes the site with llms.txt on every response", async () => {
+    const response = await SELF.fetch("https://sosumi.ai/.well-known/api-catalog")
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Link")).toContain('</llms.txt>; rel="describedby"')
+  })
+
+  it("advertises content routes as their own Markdown alternate", async () => {
+    const path = "/videos/play/invalid!/not-a-number"
+    const response = await SELF.fetch(`https://sosumi.ai${path}`)
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get("Link")).toContain('</llms.txt>; rel="describedby"')
+    expect(response.headers.get("Link")).toContain(
+      `<${path}>; rel="alternate"; type="text/markdown"`,
+    )
   })
 })

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -1,5 +1,6 @@
 import { SELF } from "cloudflare:test"
 import { describe, expect, it } from "vitest"
+import app from "../src/index"
 
 describe("Agent discovery endpoints", () => {
   it("serves an RFC 9727 API catalog", async () => {
@@ -104,14 +105,31 @@ describe("Agent discovery endpoints", () => {
     expect(response.headers.get("Link")).toContain('</llms.txt>; rel="describedby"')
   })
 
-  it("advertises content routes as their own Markdown alternate", async () => {
-    const path = "/videos/play/invalid!/not-a-number"
-    const response = await SELF.fetch(`https://sosumi.ai${path}`)
+  it("preserves Link headers from downstream responses", async () => {
+    const canonicalLink = '<https://sosumi.ai/>; rel="canonical"'
+    const response = await app.request("https://sosumi.ai/", undefined, {
+      ASSETS: {
+        fetch: async () => new Response("Homepage", { headers: { Link: canonicalLink } }),
+      } as Fetcher,
+      NODE_ENV: "production",
+    })
 
-    expect(response.status).toBe(400)
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Link")).toContain(canonicalLink)
     expect(response.headers.get("Link")).toContain('</llms.txt>; rel="describedby"')
-    expect(response.headers.get("Link")).toContain(
-      `<${path}>; rel="alternate"; type="text/markdown"`,
-    )
+  })
+
+  it("advertises content routes as their own Markdown alternate", async () => {
+    const paths = ["/videos/play/invalid!/not-a-number", "/external/not-a-url"]
+
+    for (const path of paths) {
+      const response = await SELF.fetch(`https://sosumi.ai${path}`)
+
+      expect(response.status).toBe(400)
+      expect(response.headers.get("Link")).toContain('</llms.txt>; rel="describedby"')
+      expect(response.headers.get("Link")).toContain(
+        `<${path}>; rel="alternate"; type="text/markdown"`,
+      )
+    }
   })
 })


### PR DESCRIPTION
Adds a site-wide Link relation describing responses with /llms.txt while preserving the homepage's existing discovery links. Content routes now advertise themselves as Markdown alternates for documentation, external DocC pages, Human Interface Guidelines, and video transcripts.