### PR TITLE
Serve security.txt with rolling expiry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,18 +192,19 @@ const SECURITY_TXT_EXPIRY_MS = 364 * 24 * 60 * 60 * 1000 // 364 days
 
 app.get("/.well-known/security.txt", (c) => {
   const expires = new Date(Date.now() + SECURITY_TXT_EXPIRY_MS).toISOString()
+  const origin = new URL(c.req.url).origin
 
   return c.text(
     [
       "Contact: mailto:info@sosumi.ai",
       `Expires: ${expires}`,
-      "Canonical: https://sosumi.ai/.well-known/security.txt",
+      `Canonical: ${origin}/.well-known/security.txt`,
       "Preferred-Languages: en",
       "",
     ].join("\n"),
     200,
     {
-      "Cache-Control": "public, max-age=86400",
+      ...discoveryHeaders,
       "Content-Type": "text/plain; charset=utf-8",
     },
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,6 +188,27 @@ const discoveryHeaders = {
   "Cache-Control": "public, max-age=300, s-maxage=600",
 } as const
 
+const SECURITY_TXT_EXPIRY_MS = 364 * 24 * 60 * 60 * 1000 // 364 days
+
+app.get("/.well-known/security.txt", (c) => {
+  const expires = new Date(Date.now() + SECURITY_TXT_EXPIRY_MS).toISOString()
+
+  return c.text(
+    [
+      "Contact: mailto:info@sosumi.ai",
+      `Expires: ${expires}`,
+      "Canonical: https://sosumi.ai/.well-known/security.txt",
+      "Preferred-Languages: en",
+      "",
+    ].join("\n"),
+    200,
+    {
+      "Cache-Control": "public, max-age=86400",
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  )
+})
+
 app.get("/.well-known/api-catalog", (c) => {
   const origin = new URL(c.req.url).origin
 

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest"
 describe("Agent discovery endpoints", () => {
   it("serves a security.txt file with a rolling expiry", async () => {
     const requestedAt = Date.now()
-    const response = await SELF.fetch("https://preview.sosumi.ai/.well-known/security.txt")
+    const response = await SELF.fetch("https://sosumi.ai/.well-known/security.txt")
 
     expect(response.status).toBe(200)
     expect(response.headers.get("Content-Type")).toContain("text/plain")
@@ -13,7 +13,7 @@ describe("Agent discovery endpoints", () => {
 
     const body = await response.text()
     expect(body).toContain("Contact: mailto:info@sosumi.ai")
-    expect(body).toContain("Canonical: https://preview.sosumi.ai/.well-known/security.txt")
+    expect(body).toContain("Canonical: https://sosumi.ai/.well-known/security.txt")
     expect(body).toContain("Preferred-Languages: en")
 
     const expires = body.match(/^Expires: (.+)$/m)?.[1]

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -4,14 +4,16 @@ import { describe, expect, it } from "vitest"
 describe("Agent discovery endpoints", () => {
   it("serves a security.txt file with a rolling expiry", async () => {
     const requestedAt = Date.now()
-    const response = await SELF.fetch("https://sosumi.ai/.well-known/security.txt")
+    const response = await SELF.fetch("https://preview.sosumi.ai/.well-known/security.txt")
 
     expect(response.status).toBe(200)
     expect(response.headers.get("Content-Type")).toContain("text/plain")
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*")
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=300, s-maxage=600")
 
     const body = await response.text()
     expect(body).toContain("Contact: mailto:info@sosumi.ai")
-    expect(body).toContain("Canonical: https://sosumi.ai/.well-known/security.txt")
+    expect(body).toContain("Canonical: https://preview.sosumi.ai/.well-known/security.txt")
     expect(body).toContain("Preferred-Languages: en")
 
     const expires = body.match(/^Expires: (.+)$/m)?.[1]

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -2,6 +2,26 @@ import { SELF } from "cloudflare:test"
 import { describe, expect, it } from "vitest"
 
 describe("Agent discovery endpoints", () => {
+  it("serves a security.txt file with a rolling expiry", async () => {
+    const requestedAt = Date.now()
+    const response = await SELF.fetch("https://sosumi.ai/.well-known/security.txt")
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Content-Type")).toContain("text/plain")
+
+    const body = await response.text()
+    expect(body).toContain("Contact: mailto:info@sosumi.ai")
+    expect(body).toContain("Canonical: https://sosumi.ai/.well-known/security.txt")
+    expect(body).toContain("Preferred-Languages: en")
+
+    const expires = body.match(/^Expires: (.+)$/m)?.[1]
+    expect(expires).toBeDefined()
+
+    const expiresAt = Date.parse(expires ?? "")
+    expect(expiresAt).toBeGreaterThan(requestedAt + 363 * 24 * 60 * 60 * 1000)
+    expect(expiresAt).toBeLessThan(requestedAt + 365 * 24 * 60 * 60 * 1000)
+  })
+
   it("serves an RFC 9727 API catalog", async () => {
     const response = await SELF.fetch("https://sosumi.ai/.well-known/api-catalog")
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,12 @@
   "assets": {
     "binding": "ASSETS",
     "directory": "./public",
-    "run_worker_first": ["/", "/.well-known/agent-card.json", "/.well-known/agent-skills/*"]
+    "run_worker_first": [
+      "/",
+      "/.well-known/agent-card.json",
+      "/.well-known/agent-skills/*",
+      "/.well-known/security.txt"
+    ]
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
See https://securitytxt.org

Serve RFC 9116 security.txt dynamically with a rolling 364-day expiry.