### PR TITLE
Implement A2A message handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
   capabilityError,
   createA2AErrorResponse,
   handleA2AMessage,
+  parseA2AListTasksQuery,
   pushNotificationsNotSupported,
   readA2ACapabilityText,
   readA2AJsonBody,
@@ -401,7 +402,8 @@ app.post("/message:stream", (c) =>
 app.get("/tasks", (c) => {
   try {
     validateA2ARequestHeaders(null, requestedA2AVersion(c.req.raw))
-    return c.json({ tasks: [], nextPageToken: "", pageSize: 50, totalSize: 0 }, 200, {
+    const pageSize = parseA2AListTasksQuery(new URL(c.req.url).searchParams)
+    return c.json({ tasks: [], nextPageToken: "", pageSize, totalSize: 0 }, 200, {
       "Content-Type": A2A_MEDIA_TYPE,
       "Cache-Control": "no-store",
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,16 @@ import { cache } from "hono/cache"
 import { cors } from "hono/cors"
 import { HTTPException } from "hono/http-exception"
 import { trimTrailingSlash } from "hono/trailing-slash"
-import { buildAgentCard } from "./lib/a2a"
+import {
+  A2A_MEDIA_TYPE,
+  A2A_MESSAGE_PATH,
+  A2AError,
+  buildAgentCard,
+  capabilityError,
+  handleA2AMessage,
+  toA2AErrorResponse,
+  validateA2ARequestHeaders,
+} from "./lib/a2a"
 import { AI_CATALOG_MEDIA_TYPE, buildAiCatalog } from "./lib/ard"
 import { buildDidDocument, DID_DOCUMENT_MEDIA_TYPE } from "./lib/did"
 import {
@@ -318,6 +327,58 @@ app.get("/.well-known/agent-card.json", (c) => {
     ...discoveryHeaders,
     "Content-Type": "application/json; charset=utf-8",
   })
+})
+
+app.post(A2A_MESSAGE_PATH, async (c) => {
+  try {
+    validateA2ARequestHeaders(
+      c.req.header("Content-Type") ?? null,
+      c.req.header("A2A-Version") ?? c.req.query("A2A-Version") ?? null,
+    )
+
+    let input: unknown
+    try {
+      input = await c.req.json<unknown>()
+    } catch {
+      const failure = toA2AErrorResponse(
+        new A2AError(400, "INVALID_ARGUMENT", "REQUEST_MALFORMED", "Invalid JSON payload."),
+      )
+      return c.json(failure.body, failure.statusCode, {
+        "Content-Type": A2A_MEDIA_TYPE,
+        "Cache-Control": "no-store",
+      })
+    }
+
+    const response = await handleA2AMessage(input, async (endpoint, outputMode) => {
+      const capabilityResponse = await app.request(
+        new URL(endpoint, c.req.url).toString(),
+        { headers: { Accept: outputMode } },
+        c.env,
+      )
+      const text = await capabilityResponse.text()
+      if (!capabilityResponse.ok) {
+        throw capabilityError(
+          capabilityResponse.status,
+          text || `Sosumi capability request failed with status ${capabilityResponse.status}.`,
+        )
+      }
+      return text
+    })
+
+    return c.json(response, 200, {
+      "Content-Type": A2A_MEDIA_TYPE,
+      "Cache-Control": "no-store",
+    })
+  } catch (error) {
+    if (!(error instanceof A2AError)) {
+      console.error("A2A message execution failed", error)
+    }
+    const failure = toA2AErrorResponse(error)
+    return c.json(failure.body, failure.statusCode, {
+      "Content-Type": A2A_MEDIA_TYPE,
+      "Cache-Control": "no-store",
+    })
+  }
 })
 
 app.get("/webmcp/manifest.json", (c) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,13 @@ import {
   A2AError,
   buildAgentCard,
   capabilityError,
+  createA2AErrorResponse,
   handleA2AMessage,
-  toA2AErrorResponse,
+  pushNotificationsNotSupported,
+  readA2ACapabilityText,
+  readA2AJsonBody,
+  taskNotFound,
+  unsupportedOperation,
   validateA2ARequestHeaders,
 } from "./lib/a2a"
 import { AI_CATALOG_MEDIA_TYPE, buildAiCatalog } from "./lib/ard"
@@ -61,6 +66,32 @@ interface Env {
 }
 
 const app = new Hono<{ Bindings: Env }>()
+
+function requestedA2AVersion(request: Request): string | null {
+  return request.headers.get("A2A-Version") ?? new URL(request.url).searchParams.get("A2A-Version")
+}
+
+function fixedA2AError(request: Request, error: A2AError): Response {
+  try {
+    validateA2ARequestHeaders(
+      request.method === "POST" ? request.headers.get("Content-Type") : null,
+      requestedA2AVersion(request),
+    )
+    return createA2AErrorResponse(error)
+  } catch (headerError) {
+    return createA2AErrorResponse(headerError)
+  }
+}
+
+function taskIdFromPath(path: string): string {
+  const taskPath = path.slice("/tasks/".length)
+  const encodedTaskId = taskPath.split(/[:/]/, 1)[0] ?? ""
+  try {
+    return decodeURIComponent(encodedTaskId) || "unknown"
+  } catch {
+    return encodedTaskId || "unknown"
+  }
+}
 
 function isMarkdownContentRoute(path: string): boolean {
   return (
@@ -331,23 +362,9 @@ app.get("/.well-known/agent-card.json", (c) => {
 
 app.post(A2A_MESSAGE_PATH, async (c) => {
   try {
-    validateA2ARequestHeaders(
-      c.req.header("Content-Type") ?? null,
-      c.req.header("A2A-Version") ?? c.req.query("A2A-Version") ?? null,
-    )
+    validateA2ARequestHeaders(c.req.header("Content-Type") ?? null, requestedA2AVersion(c.req.raw))
 
-    let input: unknown
-    try {
-      input = await c.req.json<unknown>()
-    } catch {
-      const failure = toA2AErrorResponse(
-        new A2AError(400, "INVALID_ARGUMENT", "REQUEST_MALFORMED", "Invalid JSON payload."),
-      )
-      return c.json(failure.body, failure.statusCode, {
-        "Content-Type": A2A_MEDIA_TYPE,
-        "Cache-Control": "no-store",
-      })
-    }
+    const input = await readA2AJsonBody(c.req.raw)
 
     const response = await handleA2AMessage(input, async (endpoint, outputMode) => {
       const capabilityResponse = await app.request(
@@ -355,7 +372,7 @@ app.post(A2A_MESSAGE_PATH, async (c) => {
         { headers: { Accept: outputMode } },
         c.env,
       )
-      const text = await capabilityResponse.text()
+      const text = await readA2ACapabilityText(capabilityResponse)
       if (!capabilityResponse.ok) {
         throw capabilityError(
           capabilityResponse.status,
@@ -373,13 +390,41 @@ app.post(A2A_MESSAGE_PATH, async (c) => {
     if (!(error instanceof A2AError)) {
       console.error("A2A message execution failed", error)
     }
-    const failure = toA2AErrorResponse(error)
-    return c.json(failure.body, failure.statusCode, {
+    return createA2AErrorResponse(error)
+  }
+})
+
+app.post("/message:stream", (c) =>
+  fixedA2AError(c.req.raw, unsupportedOperation("Streaming messages")),
+)
+
+app.get("/tasks", (c) => {
+  try {
+    validateA2ARequestHeaders(null, requestedA2AVersion(c.req.raw))
+    return c.json({ tasks: [], nextPageToken: "", pageSize: 50, totalSize: 0 }, 200, {
       "Content-Type": A2A_MEDIA_TYPE,
       "Cache-Control": "no-store",
     })
+  } catch (error) {
+    return createA2AErrorResponse(error)
   }
 })
+
+app.all("/tasks", (c) => fixedA2AError(c.req.raw, unsupportedOperation("This task operation")))
+
+app.all("/tasks/*", (c) => {
+  if (c.req.path.includes("/pushNotificationConfigs")) {
+    return fixedA2AError(c.req.raw, pushNotificationsNotSupported())
+  }
+  if (c.req.path.endsWith(":subscribe")) {
+    return fixedA2AError(c.req.raw, unsupportedOperation("Task subscriptions"))
+  }
+  return fixedA2AError(c.req.raw, taskNotFound(taskIdFromPath(c.req.path)))
+})
+
+app.get("/extendedAgentCard", (c) =>
+  fixedA2AError(c.req.raw, unsupportedOperation("Extended Agent Cards")),
+)
 
 app.get("/webmcp/manifest.json", (c) =>
   c.json(buildWebMcpManifest(), 200, {

--- a/src/lib/a2a.ts
+++ b/src/lib/a2a.ts
@@ -105,7 +105,15 @@ export function buildAgentCard(origin: string) {
 
 type A2AHttpStatus = 400 | 403 | 404 | 413 | 500 | 503
 
+const INT32_MAX = 2_147_483_647
 const metadataSchema = z.record(z.unknown())
+
+const nonNegativeInt32Schema = z.preprocess((value) => {
+  if (typeof value === "string" && /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(value)) {
+    return Number(value)
+  }
+  return value
+}, z.number().int().nonnegative().max(INT32_MAX))
 
 const authenticationInfoSchema = z
   .object({
@@ -129,7 +137,7 @@ const sendMessageConfigurationSchema = z
   .object({
     acceptedOutputModes: z.array(z.string()).optional(),
     taskPushNotificationConfig: taskPushNotificationConfigSchema.optional(),
-    historyLength: z.number().int().nonnegative().optional(),
+    historyLength: nonNegativeInt32Schema.optional(),
     returnImmediately: z.boolean().optional(),
   })
   .strict()
@@ -417,15 +425,11 @@ export function parseA2AListTasksQuery(query: URLSearchParams): number {
     throw malformed(`Invalid task status "${status}".`)
   }
 
-  parseIntegerQuery(query.get("historyLength"), "historyLength", 0)
+  parseIntegerQuery(query.get("historyLength"), "historyLength", 0, INT32_MAX)
 
   const timestamp = query.get("statusTimestampAfter")
-  if (
-    timestamp !== null &&
-    (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/.test(timestamp) ||
-      Number.isNaN(Date.parse(timestamp)))
-  ) {
-    throw malformed("statusTimestampAfter must be an ISO 8601 UTC timestamp.")
+  if (timestamp !== null && !isValidProtobufTimestamp(timestamp)) {
+    throw malformed("statusTimestampAfter must be a valid RFC 3339 protobuf Timestamp.")
   }
 
   const includeArtifacts = query.get("includeArtifacts")
@@ -647,6 +651,58 @@ function parseIntegerQuery(
     throw malformed(`${name} must be between ${minimum} and ${maximum}.`)
   }
   return parsed
+}
+
+function isValidProtobufTimestamp(value: string): boolean {
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|([+-])(\d{2}):(\d{2}))$/.exec(
+      value,
+    )
+  if (!match) {
+    return false
+  }
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const hour = Number(match[4])
+  const minute = Number(match[5])
+  const second = Number(match[6])
+  const fraction = match[7] ?? ""
+  const offsetHour = Number(match[10] ?? 0)
+  const offsetMinute = Number(match[11] ?? 0)
+
+  if (
+    year < 1 ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > daysInMonth(year, month) ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHour > 23 ||
+    offsetMinute > 59
+  ) {
+    return false
+  }
+
+  const localTime = new Date(0)
+  localTime.setUTCFullYear(year, month - 1, day)
+  localTime.setUTCHours(hour, minute, second, Number(fraction.padEnd(3, "0").slice(0, 3)))
+
+  const offsetSign = match[9] === "-" ? -1 : 1
+  const offsetMilliseconds = offsetSign * (offsetHour * 60 + offsetMinute) * 60_000
+  const instant = localTime.getTime() - offsetMilliseconds
+  return instant >= -62_135_596_800_000 && instant <= 253_402_300_799_999
+}
+
+function daysInMonth(year: number, month: number): number {
+  if (month === 2) {
+    const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+    return leapYear ? 29 : 28
+  }
+  return [4, 6, 9, 11].includes(month) ? 30 : 31
 }
 
 function capabilityResponseTooLarge(): A2AError {

--- a/src/lib/a2a.ts
+++ b/src/lib/a2a.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import { resolveFetchEndpoint, resolveSearchEndpoint } from "./cli-endpoints"
 import { MCP_SERVER_INFO, TOOL_DEFINITIONS } from "./mcp"
 
@@ -15,6 +16,12 @@ export const A2A_MESSAGE_PATH = "/message:send"
 
 /** The media type returned by every Sosumi A2A skill. */
 export const A2A_OUTPUT_MEDIA_TYPE = "text/markdown"
+
+/** Maximum wire size accepted for an unauthenticated A2A request body. */
+export const A2A_MAX_REQUEST_BYTES = 32 * 1024
+
+/** Maximum capability output that can be safely wrapped in an A2A JSON response. */
+export const A2A_MAX_RESPONSE_BYTES = 8 * 1024 * 1024
 
 /**
  * The transport binding advertised for the agent's interface.
@@ -96,9 +103,70 @@ export function buildAgentCard(origin: string) {
   }
 }
 
-type A2AHttpStatus = 400 | 403 | 404 | 500 | 502
+type A2AHttpStatus = 400 | 403 | 404 | 413 | 500 | 503
 
-type JsonRecord = Record<string, unknown>
+const metadataSchema = z.record(z.unknown())
+
+const authenticationInfoSchema = z
+  .object({
+    scheme: z.string().min(1),
+    credentials: z.string().optional(),
+  })
+  .strict()
+
+const taskPushNotificationConfigSchema = z
+  .object({
+    tenant: z.string().optional(),
+    id: z.string().optional(),
+    taskId: z.string().optional(),
+    url: z.string().url(),
+    token: z.string().optional(),
+    authentication: authenticationInfoSchema.optional(),
+  })
+  .strict()
+
+const sendMessageConfigurationSchema = z
+  .object({
+    acceptedOutputModes: z.array(z.string()).optional(),
+    taskPushNotificationConfig: taskPushNotificationConfigSchema.optional(),
+    historyLength: z.number().int().nonnegative().optional(),
+    returnImmediately: z.boolean().optional(),
+  })
+  .strict()
+
+const partSchema = z
+  .object({
+    text: z.string().optional(),
+    raw: z.string().optional(),
+    url: z.string().optional(),
+    data: z.unknown().optional(),
+    metadata: metadataSchema.optional(),
+    filename: z.string().optional(),
+    mediaType: z.string().min(1).optional(),
+  })
+  .strict()
+
+const messageSchema = z
+  .object({
+    messageId: z.string().min(1),
+    contextId: z.string().min(1).optional(),
+    taskId: z.string().min(1).optional(),
+    role: z.enum(["ROLE_UNSPECIFIED", "ROLE_USER", "ROLE_AGENT"]),
+    parts: z.array(partSchema).min(1),
+    metadata: metadataSchema.optional(),
+    extensions: z.array(z.string().min(1)).optional(),
+    referenceTaskIds: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+
+const sendMessageRequestSchema = z
+  .object({
+    tenant: z.string().optional(),
+    message: messageSchema,
+    configuration: sendMessageConfigurationSchema.optional(),
+    metadata: metadataSchema.optional(),
+  })
+  .strict()
 
 interface ParsedA2AMessage {
   contextId?: string
@@ -208,6 +276,104 @@ export function toA2AErrorResponse(error: unknown): {
   }
 }
 
+/** Serialize a failure with the response headers required by the HTTP+JSON binding. */
+export function createA2AErrorResponse(error: unknown): Response {
+  const failure = toA2AErrorResponse(error)
+  return new Response(JSON.stringify(failure.body), {
+    status: failure.statusCode,
+    headers: {
+      "Content-Type": A2A_MEDIA_TYPE,
+      "Cache-Control": "no-store",
+    },
+  })
+}
+
+/** Read and parse a JSON request without buffering more than the A2A body limit. */
+export async function readA2AJsonBody(request: Request): Promise<unknown> {
+  const contentLength = request.headers.get("Content-Length")
+  if (contentLength !== null) {
+    const declaredBytes = Number(contentLength)
+    if (!Number.isSafeInteger(declaredBytes) || declaredBytes < 0) {
+      throw malformed("Content-Length must be a non-negative integer.")
+    }
+    if (declaredBytes > A2A_MAX_REQUEST_BYTES) {
+      throw requestTooLarge()
+    }
+  }
+
+  if (!request.body) {
+    throw malformed("A JSON payload is required.")
+  }
+
+  const bytes = await readLimitedBody(request.body, A2A_MAX_REQUEST_BYTES, requestTooLarge, () =>
+    malformed("The JSON payload could not be read."),
+  )
+
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes))
+  } catch {
+    throw malformed("Invalid JSON payload.")
+  }
+}
+
+/** Read a capability response without buffering an unbounded document. */
+export async function readA2ACapabilityText(response: Response): Promise<string> {
+  const contentLength = response.headers.get("Content-Length")
+  if (contentLength !== null) {
+    const declaredBytes = Number(contentLength)
+    if (Number.isSafeInteger(declaredBytes) && declaredBytes > A2A_MAX_RESPONSE_BYTES) {
+      throw capabilityResponseTooLarge()
+    }
+  }
+
+  if (!response.body) {
+    return ""
+  }
+
+  const bytes = await readLimitedBody(
+    response.body,
+    A2A_MAX_RESPONSE_BYTES,
+    capabilityResponseTooLarge,
+    () => new A2AError(503, "UNAVAILABLE", null, "The capability response could not be read."),
+  )
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+  } catch {
+    throw new A2AError(503, "UNAVAILABLE", null, "The capability returned invalid UTF-8.")
+  }
+}
+
+/** Return the canonical error for an operation against unknown stateless task data. */
+export function taskNotFound(taskId: string): A2AError {
+  return new A2AError(
+    404,
+    "NOT_FOUND",
+    "TASK_NOT_FOUND",
+    `Task "${taskId}" was not created by this stateless agent.`,
+    { taskId },
+  )
+}
+
+/** Return the canonical error for an operation disabled by the Agent Card. */
+export function unsupportedOperation(operation: string): A2AError {
+  return new A2AError(
+    400,
+    "FAILED_PRECONDITION",
+    "UNSUPPORTED_OPERATION",
+    `${operation} is not supported by this stateless agent.`,
+  )
+}
+
+/** Return the canonical error for push operations disabled by the Agent Card. */
+export function pushNotificationsNotSupported(): A2AError {
+  return new A2AError(
+    400,
+    "FAILED_PRECONDITION",
+    "PUSH_NOTIFICATION_NOT_SUPPORTED",
+    "Sosumi does not support A2A push notifications.",
+  )
+}
+
 /**
  * Execute a synchronous A2A message using one of Sosumi's existing HTTP
  * capabilities and return a direct Message response (no persistent Task).
@@ -235,7 +401,11 @@ export function resolveA2AEndpoint(prompt: string): string {
   const fetchTarget = extractFetchTarget(prompt)
   if (fetchTarget) {
     try {
-      return resolveFetchEndpoint(fetchTarget)
+      const endpoint = resolveFetchEndpoint(fetchTarget)
+      if (endpoint.startsWith("/external/")) {
+        return `/external/${encodeURIComponent(endpoint.slice("/external/".length))}`
+      }
+      return endpoint
     } catch (error) {
       throw malformed(error instanceof Error ? error.message : "Invalid fetch target.")
     }
@@ -266,41 +436,34 @@ export function capabilityError(statusCode: number, message: string): A2AError {
   if (statusCode === 404) {
     return new A2AError(404, "NOT_FOUND", null, message)
   }
-  return new A2AError(502, "UNAVAILABLE", null, message)
+  return new A2AError(503, "UNAVAILABLE", null, message)
 }
 
 function parseA2AMessage(input: unknown): ParsedA2AMessage {
-  if (!isJsonRecord(input) || !isJsonRecord(input.message)) {
-    throw malformed("message is required.")
+  const parsed = sendMessageRequestSchema.safeParse(input)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const field = issue?.path.length ? issue.path.join(".") : "request"
+    throw malformed(`${field}: ${issue?.message ?? "Invalid A2A request."}`)
   }
 
-  const message = input.message
-  if (typeof message.messageId !== "string" || !message.messageId.trim()) {
-    throw malformed("message.messageId is required.")
+  const request = parsed.data
+  if (request.tenant) {
+    throw malformed("tenant is not supported by this interface.")
   }
+  const message = request.message
   if (message.role !== "ROLE_USER") {
     throw malformed('message.role must be "ROLE_USER".')
   }
-  if (message.contextId !== undefined && !isNonEmptyString(message.contextId)) {
-    throw malformed("message.contextId must be a non-empty string when provided.")
-  }
   if (message.taskId !== undefined) {
-    if (!isNonEmptyString(message.taskId)) {
-      throw malformed("message.taskId must be a non-empty string when provided.")
-    }
-    throw new A2AError(
-      404,
-      "NOT_FOUND",
-      "TASK_NOT_FOUND",
-      `Task "${message.taskId}" was not created by this stateless agent.`,
-      { taskId: message.taskId },
-    )
+    throw taskNotFound(message.taskId)
   }
-  if (!Array.isArray(message.parts) || message.parts.length === 0) {
-    throw malformed("message.parts must contain at least one text part.")
+  const referencedTaskId = message.referenceTaskIds?.[0]
+  if (referencedTaskId) {
+    throw taskNotFound(referencedTaskId)
   }
 
-  const textParts = message.parts.map((part, index) => parseTextPart(part, index))
+  const textParts = message.parts.map(parseTextPart)
   const prompt = textParts.join("\n").trim()
   if (!prompt) {
     throw malformed("message.parts must contain non-empty text.")
@@ -310,17 +473,13 @@ function parseA2AMessage(input: unknown): ParsedA2AMessage {
   }
 
   return {
-    contextId: typeof message.contextId === "string" ? message.contextId : undefined,
+    contextId: message.contextId,
     prompt,
-    outputMode: selectOutputMode(input.configuration),
+    outputMode: selectOutputMode(request.configuration),
   }
 }
 
-function parseTextPart(part: unknown, index: number): string {
-  if (!isJsonRecord(part)) {
-    throw malformed(`message.parts[${index}] must be an object.`)
-  }
-
+function parseTextPart(part: z.infer<typeof partSchema>): string {
   const contentFields = ["text", "raw", "url", "data"].filter((field) => field in part)
   if (contentFields.length !== 1 || contentFields[0] !== "text" || typeof part.text !== "string") {
     throw new A2AError(
@@ -342,20 +501,14 @@ function parseTextPart(part: unknown, index: number): string {
   return part.text
 }
 
-function selectOutputMode(configuration: unknown): typeof A2A_OUTPUT_MEDIA_TYPE {
+function selectOutputMode(
+  configuration: z.infer<typeof sendMessageConfigurationSchema> | undefined,
+): typeof A2A_OUTPUT_MEDIA_TYPE {
   if (configuration === undefined) {
     return A2A_OUTPUT_MEDIA_TYPE
   }
-  if (!isJsonRecord(configuration)) {
-    throw malformed("configuration must be an object when provided.")
-  }
   if (configuration.taskPushNotificationConfig !== undefined) {
-    throw new A2AError(
-      400,
-      "FAILED_PRECONDITION",
-      "PUSH_NOTIFICATION_NOT_SUPPORTED",
-      "Sosumi does not support A2A push notifications.",
-    )
+    throw pushNotificationsNotSupported()
   }
 
   const modes = configuration.acceptedOutputModes
@@ -400,13 +553,69 @@ function trimTargetPunctuation(target: string): string {
 }
 
 function malformed(message: string): A2AError {
-  return new A2AError(400, "INVALID_ARGUMENT", "REQUEST_MALFORMED", message)
+  return new A2AError(400, "INVALID_ARGUMENT", null, message)
 }
 
-function isJsonRecord(value: unknown): value is JsonRecord {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
+function requestTooLarge(): A2AError {
+  return new A2AError(
+    413,
+    "RESOURCE_EXHAUSTED",
+    null,
+    `Request body exceeds the ${A2A_MAX_REQUEST_BYTES}-byte limit.`,
+  )
 }
 
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0
+function capabilityResponseTooLarge(): A2AError {
+  return new A2AError(
+    503,
+    "UNAVAILABLE",
+    null,
+    `Capability response exceeds the ${A2A_MAX_RESPONSE_BYTES}-byte A2A limit.`,
+  )
+}
+
+async function readLimitedBody(
+  body: ReadableStream<Uint8Array>,
+  maximumBytes: number,
+  tooLarge: () => A2AError,
+  readFailure: () => A2AError,
+): Promise<Uint8Array> {
+  const reader = body.getReader()
+  const chunks: Uint8Array[] = []
+  let byteLength = 0
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) {
+        break
+      }
+
+      byteLength += value.byteLength
+      if (byteLength > maximumBytes) {
+        try {
+          await reader.cancel()
+        } catch {
+          // The bounded error below is more useful than a cancellation failure.
+        }
+        throw tooLarge()
+      }
+      chunks.push(value)
+    }
+  } catch (error) {
+    if (error instanceof A2AError) {
+      throw error
+    }
+    throw readFailure()
+  } finally {
+    reader.releaseLock()
+  }
+
+  const bytes = new Uint8Array(byteLength)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes
 }

--- a/src/lib/a2a.ts
+++ b/src/lib/a2a.ts
@@ -168,6 +168,29 @@ const sendMessageRequestSchema = z
   })
   .strict()
 
+const LIST_TASK_QUERY_FIELDS = new Set([
+  "A2A-Version",
+  "tenant",
+  "contextId",
+  "status",
+  "pageSize",
+  "pageToken",
+  "historyLength",
+  "statusTimestampAfter",
+  "includeArtifacts",
+])
+
+const TASK_STATES = new Set([
+  "TASK_STATE_SUBMITTED",
+  "TASK_STATE_WORKING",
+  "TASK_STATE_COMPLETED",
+  "TASK_STATE_FAILED",
+  "TASK_STATE_CANCELED",
+  "TASK_STATE_INPUT_REQUIRED",
+  "TASK_STATE_REJECTED",
+  "TASK_STATE_AUTH_REQUIRED",
+])
+
 interface ParsedA2AMessage {
   contextId?: string
   prompt: string
@@ -374,6 +397,45 @@ export function pushNotificationsNotSupported(): A2AError {
   )
 }
 
+/** Validate a ListTasks query and return the page size used by the empty stateless result. */
+export function parseA2AListTasksQuery(query: URLSearchParams): number {
+  for (const key of query.keys()) {
+    if (!LIST_TASK_QUERY_FIELDS.has(key)) {
+      throw malformed(`Unsupported ListTasks query field "${key}".`)
+    }
+    if (query.getAll(key).length > 1) {
+      throw malformed(`ListTasks query field "${key}" must not be repeated.`)
+    }
+  }
+
+  if (query.get("tenant")) {
+    throw malformed("tenant is not supported by this interface.")
+  }
+
+  const status = query.get("status")
+  if (status !== null && !TASK_STATES.has(status)) {
+    throw malformed(`Invalid task status "${status}".`)
+  }
+
+  parseIntegerQuery(query.get("historyLength"), "historyLength", 0)
+
+  const timestamp = query.get("statusTimestampAfter")
+  if (
+    timestamp !== null &&
+    (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/.test(timestamp) ||
+      Number.isNaN(Date.parse(timestamp)))
+  ) {
+    throw malformed("statusTimestampAfter must be an ISO 8601 UTC timestamp.")
+  }
+
+  const includeArtifacts = query.get("includeArtifacts")
+  if (includeArtifacts !== null && includeArtifacts !== "true" && includeArtifacts !== "false") {
+    throw malformed('includeArtifacts must be "true" or "false".')
+  }
+
+  return parseIntegerQuery(query.get("pageSize"), "pageSize", 1, 100) ?? 50
+}
+
 /**
  * Execute a synchronous A2A message using one of Sosumi's existing HTTP
  * capabilities and return a direct Message response (no persistent Task).
@@ -403,7 +465,9 @@ export function resolveA2AEndpoint(prompt: string): string {
     try {
       const endpoint = resolveFetchEndpoint(fetchTarget)
       if (endpoint.startsWith("/external/")) {
-        return `/external/${encodeURIComponent(endpoint.slice("/external/".length))}`
+        const target = new URL(endpoint.slice("/external/".length))
+        target.hash = ""
+        return `/external/${encodeURIComponent(target.toString())}`
       }
       return endpoint
     } catch (error) {
@@ -563,6 +627,26 @@ function requestTooLarge(): A2AError {
     null,
     `Request body exceeds the ${A2A_MAX_REQUEST_BYTES}-byte limit.`,
   )
+}
+
+function parseIntegerQuery(
+  value: string | null,
+  name: string,
+  minimum: number,
+  maximum = Number.MAX_SAFE_INTEGER,
+): number | undefined {
+  if (value === null) {
+    return undefined
+  }
+  if (!/^\d+$/.test(value)) {
+    throw malformed(`${name} must be an integer.`)
+  }
+
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw malformed(`${name} must be between ${minimum} and ${maximum}.`)
+  }
+  return parsed
 }
 
 function capabilityResponseTooLarge(): A2AError {

--- a/src/lib/a2a.ts
+++ b/src/lib/a2a.ts
@@ -13,6 +13,9 @@ export const A2A_MEDIA_TYPE = "application/a2a+json"
 /** The synchronous HTTP+JSON operation exposed by Sosumi. */
 export const A2A_MESSAGE_PATH = "/message:send"
 
+/** The media type returned by every Sosumi A2A skill. */
+export const A2A_OUTPUT_MEDIA_TYPE = "text/markdown"
+
 /**
  * The transport binding advertised for the agent's interface.
  * Sosumi exposes its documentation service over plain HTTP requests,
@@ -88,7 +91,7 @@ export function buildAgentCard(origin: string) {
       pushNotifications: false,
     },
     defaultInputModes: ["text/plain"],
-    defaultOutputModes: ["text/markdown", "text/plain"],
+    defaultOutputModes: [A2A_OUTPUT_MEDIA_TYPE],
     skills,
   }
 }
@@ -100,7 +103,7 @@ type JsonRecord = Record<string, unknown>
 interface ParsedA2AMessage {
   contextId?: string
   prompt: string
-  outputMode: "text/markdown" | "text/plain"
+  outputMode: typeof A2A_OUTPUT_MEDIA_TYPE
 }
 
 export interface A2AMessageResponse {
@@ -110,7 +113,7 @@ export interface A2AMessageResponse {
     role: "ROLE_AGENT"
     parts: Array<{
       text: string
-      mediaType: "text/markdown" | "text/plain"
+      mediaType: typeof A2A_OUTPUT_MEDIA_TYPE
     }>
   }
 }
@@ -211,7 +214,7 @@ export function toA2AErrorResponse(error: unknown): {
  */
 export async function handleA2AMessage(
   input: unknown,
-  invoke: (endpoint: string, outputMode: "text/markdown" | "text/plain") => Promise<string>,
+  invoke: (endpoint: string, outputMode: typeof A2A_OUTPUT_MEDIA_TYPE) => Promise<string>,
 ): Promise<A2AMessageResponse> {
   const request = parseA2AMessage(input)
   const endpoint = resolveA2AEndpoint(request.prompt)
@@ -339,9 +342,9 @@ function parseTextPart(part: unknown, index: number): string {
   return part.text
 }
 
-function selectOutputMode(configuration: unknown): "text/markdown" | "text/plain" {
+function selectOutputMode(configuration: unknown): typeof A2A_OUTPUT_MEDIA_TYPE {
   if (configuration === undefined) {
-    return "text/markdown"
+    return A2A_OUTPUT_MEDIA_TYPE
   }
   if (!isJsonRecord(configuration)) {
     throw malformed("configuration must be an object when provided.")
@@ -357,23 +360,20 @@ function selectOutputMode(configuration: unknown): "text/markdown" | "text/plain
 
   const modes = configuration.acceptedOutputModes
   if (modes === undefined || (Array.isArray(modes) && modes.length === 0)) {
-    return "text/markdown"
+    return A2A_OUTPUT_MEDIA_TYPE
   }
   if (!Array.isArray(modes) || !modes.every((mode) => typeof mode === "string")) {
     throw malformed("configuration.acceptedOutputModes must be an array of media types.")
   }
-  if (modes.includes("text/markdown")) {
-    return "text/markdown"
-  }
-  if (modes.includes("text/plain")) {
-    return "text/plain"
+  if (modes.includes(A2A_OUTPUT_MEDIA_TYPE)) {
+    return A2A_OUTPUT_MEDIA_TYPE
   }
 
   throw new A2AError(
     400,
     "INVALID_ARGUMENT",
     "CONTENT_TYPE_NOT_SUPPORTED",
-    "Sosumi can return text/markdown or text/plain only.",
+    `Sosumi returns ${A2A_OUTPUT_MEDIA_TYPE} only.`,
   )
 }
 

--- a/src/lib/a2a.ts
+++ b/src/lib/a2a.ts
@@ -1,10 +1,17 @@
+import { resolveFetchEndpoint, resolveSearchEndpoint } from "./cli-endpoints"
 import { MCP_SERVER_INFO, TOOL_DEFINITIONS } from "./mcp"
 
 /**
  * The A2A protocol version each interface exposes, as `major.minor`.
  * See https://a2a-protocol.org/latest/specification/
  */
-const A2A_PROTOCOL_VERSION = "0.3"
+export const A2A_PROTOCOL_VERSION = "1.0"
+
+/** The HTTP+JSON media type registered by the A2A specification. */
+export const A2A_MEDIA_TYPE = "application/a2a+json"
+
+/** The synchronous HTTP+JSON operation exposed by Sosumi. */
+export const A2A_MESSAGE_PATH = "/message:send"
 
 /**
  * The transport binding advertised for the agent's interface.
@@ -43,8 +50,6 @@ interface AgentInterface {
   protocolVersion: string
   /** Transport binding. Named `protocolBinding` by the current A2A proto schema. */
   protocolBinding: string
-  /** Alias of `protocolBinding` for clients reading the published JSON schema's `transport`. */
-  transport: string
 }
 
 /**
@@ -57,7 +62,6 @@ export function buildAgentCard(origin: string) {
     url: origin,
     protocolVersion: A2A_PROTOCOL_VERSION,
     protocolBinding: TRANSPORT,
-    transport: TRANSPORT,
   }
 
   const skills = Object.values(TOOL_DEFINITIONS).map((def) => ({
@@ -87,4 +91,322 @@ export function buildAgentCard(origin: string) {
     defaultOutputModes: ["text/markdown", "text/plain"],
     skills,
   }
+}
+
+type A2AHttpStatus = 400 | 403 | 404 | 500 | 502
+
+type JsonRecord = Record<string, unknown>
+
+interface ParsedA2AMessage {
+  contextId?: string
+  prompt: string
+  outputMode: "text/markdown" | "text/plain"
+}
+
+export interface A2AMessageResponse {
+  message: {
+    messageId: string
+    contextId: string
+    role: "ROLE_AGENT"
+    parts: Array<{
+      text: string
+      mediaType: "text/markdown" | "text/plain"
+    }>
+  }
+}
+
+export interface A2AErrorBody {
+  error: {
+    code: A2AHttpStatus
+    status: string
+    message: string
+    details: Array<{
+      "@type": "type.googleapis.com/google.rpc.ErrorInfo"
+      reason: string
+      domain: "a2a-protocol.org"
+      metadata?: Record<string, string>
+    }>
+  }
+}
+
+/** A protocol-aware error that can be serialized as google.rpc.Status JSON. */
+export class A2AError extends Error {
+  constructor(
+    readonly statusCode: A2AHttpStatus,
+    readonly status: string,
+    readonly reason: string | null,
+    message: string,
+    readonly metadata?: Record<string, string>,
+  ) {
+    super(message)
+    this.name = "A2AError"
+  }
+}
+
+/** Validate the transport headers required by the advertised A2A 1.0 interface. */
+export function validateA2ARequestHeaders(
+  contentType: string | null,
+  requestedVersion: string | null,
+): void {
+  if (contentType) {
+    const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase()
+    if (mediaType !== "application/json" && mediaType !== A2A_MEDIA_TYPE) {
+      throw new A2AError(
+        400,
+        "INVALID_ARGUMENT",
+        "CONTENT_TYPE_NOT_SUPPORTED",
+        `Unsupported Content-Type "${contentType}"; expected application/json or ${A2A_MEDIA_TYPE}.`,
+      )
+    }
+  }
+
+  // Per A2A 1.0, an omitted version header means the legacy 0.3 protocol.
+  const version = requestedVersion?.trim() || "0.3"
+  if (version !== A2A_PROTOCOL_VERSION) {
+    throw new A2AError(
+      400,
+      "FAILED_PRECONDITION",
+      "VERSION_NOT_SUPPORTED",
+      `The requested A2A protocol version "${version}" is not supported.`,
+      { requestedVersion: version, supportedVersions: A2A_PROTOCOL_VERSION },
+    )
+  }
+}
+
+/** Convert an execution or validation failure to the A2A HTTP error envelope. */
+export function toA2AErrorResponse(error: unknown): {
+  statusCode: A2AHttpStatus
+  body: A2AErrorBody
+} {
+  const protocolError =
+    error instanceof A2AError
+      ? error
+      : new A2AError(500, "INTERNAL", null, "The agent could not complete the request.")
+
+  return {
+    statusCode: protocolError.statusCode,
+    body: {
+      error: {
+        code: protocolError.statusCode,
+        status: protocolError.status,
+        message: protocolError.message,
+        details: protocolError.reason
+          ? [
+              {
+                "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                reason: protocolError.reason,
+                domain: "a2a-protocol.org",
+                ...(protocolError.metadata ? { metadata: protocolError.metadata } : {}),
+              },
+            ]
+          : [],
+      },
+    },
+  }
+}
+
+/**
+ * Execute a synchronous A2A message using one of Sosumi's existing HTTP
+ * capabilities and return a direct Message response (no persistent Task).
+ */
+export async function handleA2AMessage(
+  input: unknown,
+  invoke: (endpoint: string, outputMode: "text/markdown" | "text/plain") => Promise<string>,
+): Promise<A2AMessageResponse> {
+  const request = parseA2AMessage(input)
+  const endpoint = resolveA2AEndpoint(request.prompt)
+  const text = await invoke(endpoint, request.outputMode)
+
+  return {
+    message: {
+      messageId: crypto.randomUUID(),
+      contextId: request.contextId ?? crypto.randomUUID(),
+      role: "ROLE_AGENT",
+      parts: [{ text, mediaType: request.outputMode }],
+    },
+  }
+}
+
+/** Infer the existing Sosumi capability endpoint described by a text prompt. */
+export function resolveA2AEndpoint(prompt: string): string {
+  const fetchTarget = extractFetchTarget(prompt)
+  if (fetchTarget) {
+    try {
+      return resolveFetchEndpoint(fetchTarget)
+    } catch (error) {
+      throw malformed(error instanceof Error ? error.message : "Invalid fetch target.")
+    }
+  }
+
+  const query = prompt
+    .replace(
+      /^(?:please\s+)?(?:search|find|look up)(?:\s+(?:the\s+)?apple(?: developer)?\s+documentation)?(?:\s+(?:for|about))?\s+/i,
+      "",
+    )
+    .trim()
+
+  try {
+    return resolveSearchEndpoint(query || prompt)
+  } catch (error) {
+    throw malformed(error instanceof Error ? error.message : "Invalid search query.")
+  }
+}
+
+/** Map an existing capability's HTTP failure into the A2A error envelope. */
+export function capabilityError(statusCode: number, message: string): A2AError {
+  if (statusCode === 400) {
+    return new A2AError(400, "INVALID_ARGUMENT", null, message)
+  }
+  if (statusCode === 403) {
+    return new A2AError(403, "PERMISSION_DENIED", null, message)
+  }
+  if (statusCode === 404) {
+    return new A2AError(404, "NOT_FOUND", null, message)
+  }
+  return new A2AError(502, "UNAVAILABLE", null, message)
+}
+
+function parseA2AMessage(input: unknown): ParsedA2AMessage {
+  if (!isJsonRecord(input) || !isJsonRecord(input.message)) {
+    throw malformed("message is required.")
+  }
+
+  const message = input.message
+  if (typeof message.messageId !== "string" || !message.messageId.trim()) {
+    throw malformed("message.messageId is required.")
+  }
+  if (message.role !== "ROLE_USER") {
+    throw malformed('message.role must be "ROLE_USER".')
+  }
+  if (message.contextId !== undefined && !isNonEmptyString(message.contextId)) {
+    throw malformed("message.contextId must be a non-empty string when provided.")
+  }
+  if (message.taskId !== undefined) {
+    if (!isNonEmptyString(message.taskId)) {
+      throw malformed("message.taskId must be a non-empty string when provided.")
+    }
+    throw new A2AError(
+      404,
+      "NOT_FOUND",
+      "TASK_NOT_FOUND",
+      `Task "${message.taskId}" was not created by this stateless agent.`,
+      { taskId: message.taskId },
+    )
+  }
+  if (!Array.isArray(message.parts) || message.parts.length === 0) {
+    throw malformed("message.parts must contain at least one text part.")
+  }
+
+  const textParts = message.parts.map((part, index) => parseTextPart(part, index))
+  const prompt = textParts.join("\n").trim()
+  if (!prompt) {
+    throw malformed("message.parts must contain non-empty text.")
+  }
+  if (prompt.length > 10_000) {
+    throw malformed("Combined message text must not exceed 10,000 characters.")
+  }
+
+  return {
+    contextId: typeof message.contextId === "string" ? message.contextId : undefined,
+    prompt,
+    outputMode: selectOutputMode(input.configuration),
+  }
+}
+
+function parseTextPart(part: unknown, index: number): string {
+  if (!isJsonRecord(part)) {
+    throw malformed(`message.parts[${index}] must be an object.`)
+  }
+
+  const contentFields = ["text", "raw", "url", "data"].filter((field) => field in part)
+  if (contentFields.length !== 1 || contentFields[0] !== "text" || typeof part.text !== "string") {
+    throw new A2AError(
+      400,
+      "INVALID_ARGUMENT",
+      "CONTENT_TYPE_NOT_SUPPORTED",
+      "Sosumi accepts text message parts only.",
+    )
+  }
+  if (part.mediaType !== undefined && part.mediaType !== "text/plain") {
+    throw new A2AError(
+      400,
+      "INVALID_ARGUMENT",
+      "CONTENT_TYPE_NOT_SUPPORTED",
+      `Unsupported input media type "${String(part.mediaType)}"; expected text/plain.`,
+    )
+  }
+
+  return part.text
+}
+
+function selectOutputMode(configuration: unknown): "text/markdown" | "text/plain" {
+  if (configuration === undefined) {
+    return "text/markdown"
+  }
+  if (!isJsonRecord(configuration)) {
+    throw malformed("configuration must be an object when provided.")
+  }
+  if (configuration.taskPushNotificationConfig !== undefined) {
+    throw new A2AError(
+      400,
+      "FAILED_PRECONDITION",
+      "PUSH_NOTIFICATION_NOT_SUPPORTED",
+      "Sosumi does not support A2A push notifications.",
+    )
+  }
+
+  const modes = configuration.acceptedOutputModes
+  if (modes === undefined || (Array.isArray(modes) && modes.length === 0)) {
+    return "text/markdown"
+  }
+  if (!Array.isArray(modes) || !modes.every((mode) => typeof mode === "string")) {
+    throw malformed("configuration.acceptedOutputModes must be an array of media types.")
+  }
+  if (modes.includes("text/markdown")) {
+    return "text/markdown"
+  }
+  if (modes.includes("text/plain")) {
+    return "text/plain"
+  }
+
+  throw new A2AError(
+    400,
+    "INVALID_ARGUMENT",
+    "CONTENT_TYPE_NOT_SUPPORTED",
+    "Sosumi can return text/markdown or text/plain only.",
+  )
+}
+
+function extractFetchTarget(prompt: string): string | null {
+  const url = prompt.match(/https:\/\/[^\s<>"'`]+/i)?.[0]
+  if (url) {
+    return trimTargetPunctuation(url)
+  }
+
+  const pathPrefixes = ["/documentation/", "/design/human-interface-guidelines", "/videos/play/"]
+  const lowerPrompt = prompt.toLowerCase()
+  for (const prefix of pathPrefixes) {
+    const index = lowerPrompt.indexOf(prefix)
+    if (index >= 0) {
+      return trimTargetPunctuation(prompt.slice(index).split(/\s/, 1)[0] ?? "")
+    }
+  }
+
+  return null
+}
+
+function trimTargetPunctuation(target: string): string {
+  return target.replace(/[`'",.;:!?\])}]+$/g, "")
+}
+
+function malformed(message: string): A2AError {
+  return new A2AError(400, "INVALID_ARGUMENT", "REQUEST_MALFORMED", message)
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0
 }

--- a/src/lib/ard.ts
+++ b/src/lib/ard.ts
@@ -47,6 +47,19 @@ export function buildAiCatalog(origin: string): AiCatalog {
         ],
       },
       {
+        identifier: `urn:air:${PUBLISHER_DOMAIN}:agent:documentation`,
+        displayName: "Sosumi Documentation Agent",
+        type: "application/a2a-agent-card+json",
+        url: `${origin}/.well-known/agent-card.json`,
+        description:
+          "An A2A agent for searching and fetching Apple and Swift-DocC documentation as text or Markdown.",
+        representativeQueries: [
+          "Find Apple documentation about Swift actors",
+          "Fetch the SwiftUI View documentation as Markdown",
+          "Fetch the transcript for /videos/play/wwdc2021/10133",
+        ],
+      },
+      {
         identifier: `urn:air:${PUBLISHER_DOMAIN}:skill:${SKILL_NAME}`,
         displayName: "Sosumi Agent Skill",
         type: 'text/markdown; profile="urn:air:agent-skills"',

--- a/src/lib/ard.ts
+++ b/src/lib/ard.ts
@@ -52,10 +52,10 @@ export function buildAiCatalog(origin: string): AiCatalog {
         type: "application/a2a-agent-card+json",
         url: `${origin}/.well-known/agent-card.json`,
         description:
-          "An A2A agent for searching and fetching Apple and Swift-DocC documentation as text or Markdown.",
+          "An A2A agent for searching and fetching Apple and Swift-DocC documentation as Markdown.",
         representativeQueries: [
           "Find Apple documentation about Swift actors",
-          "Fetch the SwiftUI View documentation as Markdown",
+          "Fetch /documentation/swiftui/view as Markdown",
           "Fetch the transcript for /videos/play/wwdc2021/10133",
         ],
       },

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -1,0 +1,172 @@
+import { env } from "cloudflare:test"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import app from "../src/index"
+import {
+  A2A_MEDIA_TYPE,
+  A2A_PROTOCOL_VERSION,
+  type A2AMessageResponse,
+  handleA2AMessage,
+  resolveA2AEndpoint,
+  validateA2ARequestHeaders,
+} from "../src/lib/a2a"
+
+const originalFetch = globalThis.fetch
+
+function userMessage(text: string, extra: Record<string, unknown> = {}) {
+  return {
+    message: {
+      messageId: "client-message-1",
+      role: "ROLE_USER",
+      parts: [{ text, mediaType: "text/plain" }],
+      ...extra,
+    },
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  globalThis.fetch = originalFetch
+})
+
+describe("A2A HTTP+JSON service", () => {
+  it("routes fetch prompts to an existing documentation capability", async () => {
+    const invoke = vi.fn(async () => "# View\n\nSwiftUI view documentation.")
+
+    const result = await handleA2AMessage(
+      {
+        ...userMessage("Fetch /documentation/swiftui/view as Markdown"),
+        configuration: { acceptedOutputModes: ["text/markdown"] },
+      },
+      invoke,
+    )
+
+    expect(invoke).toHaveBeenCalledWith("/documentation/swiftui/view", "text/markdown")
+    expect(result.message).toMatchObject({
+      role: "ROLE_AGENT",
+      parts: [{ text: expect.stringContaining("SwiftUI"), mediaType: "text/markdown" }],
+    })
+    expect(result.message.messageId).toBeTruthy()
+    expect(result.message.contextId).toBeTruthy()
+  })
+
+  it("preserves context and honors text/plain output negotiation", async () => {
+    const result = await handleA2AMessage(
+      {
+        ...userMessage("Find Apple documentation about Swift actors", {
+          contextId: "conversation-1",
+        }),
+        configuration: { acceptedOutputModes: ["text/plain"] },
+      },
+      async () => "Search results",
+    )
+
+    expect(result.message.contextId).toBe("conversation-1")
+    expect(result.message.parts[0]?.mediaType).toBe("text/plain")
+  })
+
+  it("normalizes natural-language searches and supported fetch targets", () => {
+    expect(resolveA2AEndpoint("Search Apple Developer documentation for URLSession")).toBe(
+      "/search?q=URLSession",
+    )
+    expect(
+      resolveA2AEndpoint("Read https://developer.apple.com/videos/play/wwdc2021/10133/ for me."),
+    ).toBe("/videos/play/wwdc2021/10133")
+  })
+
+  it("requires the protocol version advertised by the Agent Card", () => {
+    expect(() => validateA2ARequestHeaders(A2A_MEDIA_TYPE, A2A_PROTOCOL_VERSION)).not.toThrow()
+    expect(() => validateA2ARequestHeaders(A2A_MEDIA_TYPE, null)).toThrow(
+      expect.objectContaining({ reason: "VERSION_NOT_SUPPORTED" }),
+    )
+  })
+
+  it("executes search messages through POST /message:send", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          kind: "quickSearch",
+          response: {
+            results: [
+              {
+                metadata: {
+                  title: "URLSession",
+                  permalink: "https://developer.apple.com/documentation/foundation/urlsession",
+                  description: "An object that coordinates network data transfer tasks.",
+                  hierarchy: "Foundation > URLSession",
+                  kind: "class",
+                  metadataKind: "documentation",
+                },
+              },
+            ],
+          },
+        }),
+        { headers: { "Content-Type": "application/jsonl" } },
+      ),
+    )
+
+    const response = await app.request(
+      "https://sosumi.ai/message:send",
+      {
+        method: "POST",
+        headers: {
+          "A2A-Version": A2A_PROTOCOL_VERSION,
+          "Content-Type": A2A_MEDIA_TYPE,
+        },
+        body: JSON.stringify(userMessage("Search Apple Developer documentation for URLSession")),
+      },
+      { ASSETS: env.ASSETS, NODE_ENV: "development" },
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Content-Type")).toContain(A2A_MEDIA_TYPE)
+    expect(response.headers.get("Cache-Control")).toBe("no-store")
+
+    const body = (await response.json()) as A2AMessageResponse
+    expect(body.message.role).toBe("ROLE_AGENT")
+    expect(body.message.parts[0]).toMatchObject({
+      mediaType: "text/markdown",
+      text: expect.stringContaining(
+        "https://developer.apple.com/documentation/foundation/urlsession",
+      ),
+    })
+  })
+
+  it("returns protocol errors for malformed requests", async () => {
+    const [missingVersion, malformedJson] = await Promise.all([
+      app.request(
+        "https://sosumi.ai/message:send",
+        {
+          method: "POST",
+          headers: { "Content-Type": A2A_MEDIA_TYPE },
+          body: JSON.stringify(userMessage("Search for SwiftUI")),
+        },
+        { ASSETS: env.ASSETS, NODE_ENV: "development" },
+      ),
+      app.request(
+        "https://sosumi.ai/message:send",
+        {
+          method: "POST",
+          headers: {
+            "A2A-Version": A2A_PROTOCOL_VERSION,
+            "Content-Type": A2A_MEDIA_TYPE,
+          },
+          body: "{",
+        },
+        { ASSETS: env.ASSETS, NODE_ENV: "development" },
+      ),
+    ])
+
+    expect(missingVersion.status).toBe(400)
+    expect(malformedJson.status).toBe(400)
+
+    const missingVersionBody = (await missingVersion.json()) as {
+      error: { details: Array<{ reason: string }> }
+    }
+    const malformedJsonBody = (await malformedJson.json()) as {
+      error: { code: number; details: Array<{ reason: string }> }
+    }
+    expect(missingVersionBody.error.details[0]?.reason).toBe("VERSION_NOT_SUPPORTED")
+    expect(malformedJsonBody.error.code).toBe(400)
+    expect(malformedJsonBody.error.details[0]?.reason).toBe("REQUEST_MALFORMED")
+  })
+})

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -230,6 +230,28 @@ describe("A2A HTTP+JSON service", () => {
     expect(invoke).not.toHaveBeenCalled()
   })
 
+  it("enforces the protobuf int32 range for SendMessage history length", async () => {
+    await expect(
+      handleA2AMessage(
+        {
+          ...userMessage("Search for SwiftUI"),
+          configuration: { historyLength: "2147483647" },
+        },
+        async () => "Results",
+      ),
+    ).resolves.toBeTruthy()
+
+    await expect(
+      handleA2AMessage(
+        {
+          ...userMessage("Search for SwiftUI"),
+          configuration: { historyLength: 2_147_483_648 },
+        },
+        async () => "Unexpected",
+      ),
+    ).rejects.toMatchObject({ statusCode: 400, status: "INVALID_ARGUMENT" })
+  })
+
   it("rejects oversized request bodies before parsing them", async () => {
     const response = await app.request(
       "https://sosumi.ai/message:send",
@@ -305,15 +327,28 @@ describe("A2A HTTP+JSON service", () => {
   it("validates and reports the ListTasks page size", async () => {
     const headers = { "A2A-Version": A2A_PROTOCOL_VERSION }
     const bindings = { ASSETS: env.ASSETS, NODE_ENV: "development" }
-    const [selected, tooSmall, tooLarge, malformed] = await Promise.all([
-      app.request("https://sosumi.ai/tasks?pageSize=10", { headers }, bindings),
-      app.request("https://sosumi.ai/tasks?pageSize=0", { headers }, bindings),
-      app.request("https://sosumi.ai/tasks?pageSize=101", { headers }, bindings),
-      app.request("https://sosumi.ai/tasks?pageSize=ten", { headers }, bindings),
-    ])
+    const [selected, validTimestamp, tooSmall, tooLarge, malformed, historyOverflow, invalidDate] =
+      await Promise.all([
+        app.request("https://sosumi.ai/tasks?pageSize=10", { headers }, bindings),
+        app.request(
+          "https://sosumi.ai/tasks?historyLength=2147483647&statusTimestampAfter=2025-01-01T01%3A00%3A00%2B01%3A00",
+          { headers },
+          bindings,
+        ),
+        app.request("https://sosumi.ai/tasks?pageSize=0", { headers }, bindings),
+        app.request("https://sosumi.ai/tasks?pageSize=101", { headers }, bindings),
+        app.request("https://sosumi.ai/tasks?pageSize=ten", { headers }, bindings),
+        app.request("https://sosumi.ai/tasks?historyLength=2147483648", { headers }, bindings),
+        app.request(
+          "https://sosumi.ai/tasks?statusTimestampAfter=2025-02-30T00%3A00%3A00Z",
+          { headers },
+          bindings,
+        ),
+      ])
 
     await expect(selected.json()).resolves.toMatchObject({ pageSize: 10, totalSize: 0 })
-    for (const response of [tooSmall, tooLarge, malformed]) {
+    expect(validTimestamp.status).toBe(200)
+    for (const response of [tooSmall, tooLarge, malformed, historyOverflow, invalidDate]) {
       expect(response.status).toBe(400)
       await expect(response.json()).resolves.toMatchObject({
         error: { code: 400, status: "INVALID_ARGUMENT" },

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -2,10 +2,14 @@ import { env } from "cloudflare:test"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import app from "../src/index"
 import {
+  A2A_MAX_REQUEST_BYTES,
+  A2A_MAX_RESPONSE_BYTES,
   A2A_MEDIA_TYPE,
   A2A_PROTOCOL_VERSION,
   type A2AMessageResponse,
+  capabilityError,
   handleA2AMessage,
+  readA2ACapabilityText,
   resolveA2AEndpoint,
   validateA2ARequestHeaders,
 } from "../src/lib/a2a"
@@ -95,6 +99,14 @@ describe("A2A HTTP+JSON service", () => {
     expect(
       resolveA2AEndpoint("Read https://developer.apple.com/videos/play/wwdc2021/10133/ for me."),
     ).toBe("/videos/play/wwdc2021/10133")
+
+    const externalTarget =
+      "https://apple.github.io/swift-argument-parser/documentation/argumentparser?language=swift#overview"
+    const externalEndpoint = resolveA2AEndpoint(`Fetch ${externalTarget}`)
+    const internalUrl = new URL(externalEndpoint, "https://sosumi.ai")
+    expect(internalUrl.search).toBe("")
+    expect(internalUrl.hash).toBe("")
+    expect(decodeURIComponent(internalUrl.pathname.slice("/external/".length))).toBe(externalTarget)
   })
 
   it("requires the protocol version advertised by the Agent Card", () => {
@@ -187,10 +199,120 @@ describe("A2A HTTP+JSON service", () => {
       error: { details: Array<{ reason: string }> }
     }
     const malformedJsonBody = (await malformedJson.json()) as {
-      error: { code: number; details: Array<{ reason: string }> }
+      error: { code: number; status: string; details: unknown[] }
     }
     expect(missingVersionBody.error.details[0]?.reason).toBe("VERSION_NOT_SUPPORTED")
     expect(malformedJsonBody.error.code).toBe(400)
-    expect(malformedJsonBody.error.details[0]?.reason).toBe("REQUEST_MALFORMED")
+    expect(malformedJsonBody.error.status).toBe("INVALID_ARGUMENT")
+    expect(malformedJsonBody.error.details).toEqual([])
+  })
+
+  it("validates the complete SendMessage request before invoking a capability", async () => {
+    const invoke = vi.fn(async () => "Unexpected")
+    const valid = userMessage("Search for SwiftUI")
+    const malformedRequests = [
+      { ...valid, tenant: 42 },
+      { ...valid, metadata: [] },
+      { ...valid, configuration: { returnImmediately: "yes" } },
+      { ...valid, message: { ...valid.message, metadata: [] } },
+      { ...valid, message: { ...valid.message, parts: [{ text: "SwiftUI", extra: true }] } },
+    ]
+
+    for (const request of malformedRequests) {
+      await expect(handleA2AMessage(request, invoke)).rejects.toMatchObject({
+        statusCode: 400,
+        status: "INVALID_ARGUMENT",
+      })
+    }
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it("rejects oversized request bodies before parsing them", async () => {
+    const response = await app.request(
+      "https://sosumi.ai/message:send",
+      {
+        method: "POST",
+        headers: {
+          "A2A-Version": A2A_PROTOCOL_VERSION,
+          "Content-Type": A2A_MEDIA_TYPE,
+        },
+        body: JSON.stringify(userMessage("x".repeat(A2A_MAX_REQUEST_BYTES))),
+      },
+      { ASSETS: env.ASSETS, NODE_ENV: "development" },
+    )
+
+    expect(response.status).toBe(413)
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 413, status: "RESOURCE_EXHAUSTED" },
+    })
+  })
+
+  it("serves the stateless task surface with A2A protocol responses", async () => {
+    const headers = { "A2A-Version": A2A_PROTOCOL_VERSION }
+    const bindings = { ASSETS: env.ASSETS, NODE_ENV: "development" }
+    const [list, missing, cancel, stream, subscribe, push, extended] = await Promise.all([
+      app.request("https://sosumi.ai/tasks", { headers }, bindings),
+      app.request("https://sosumi.ai/tasks/missing", { headers }, bindings),
+      app.request(
+        "https://sosumi.ai/tasks/missing:cancel",
+        { method: "POST", headers: { ...headers, "Content-Type": A2A_MEDIA_TYPE } },
+        bindings,
+      ),
+      app.request(
+        "https://sosumi.ai/message:stream",
+        { method: "POST", headers: { ...headers, "Content-Type": A2A_MEDIA_TYPE } },
+        bindings,
+      ),
+      app.request("https://sosumi.ai/tasks/missing:subscribe", { headers }, bindings),
+      app.request(
+        "https://sosumi.ai/tasks/missing/pushNotificationConfigs",
+        { method: "POST", headers: { ...headers, "Content-Type": A2A_MEDIA_TYPE } },
+        bindings,
+      ),
+      app.request("https://sosumi.ai/extendedAgentCard", { headers }, bindings),
+    ])
+
+    expect(await list.json()).toEqual({
+      tasks: [],
+      nextPageToken: "",
+      pageSize: 50,
+      totalSize: 0,
+    })
+    expect(missing.status).toBe(404)
+
+    const reasons = await Promise.all(
+      [missing, cancel, stream, subscribe, push, extended].map(async (response) => {
+        expect(response.headers.get("Content-Type")).toContain(A2A_MEDIA_TYPE)
+        const body = (await response.json()) as {
+          error: { details: Array<{ reason: string }> }
+        }
+        return body.error.details[0]?.reason
+      }),
+    )
+    expect(reasons).toEqual([
+      "TASK_NOT_FOUND",
+      "TASK_NOT_FOUND",
+      "UNSUPPORTED_OPERATION",
+      "UNSUPPORTED_OPERATION",
+      "PUSH_NOTIFICATION_NOT_SUPPORTED",
+      "UNSUPPORTED_OPERATION",
+    ])
+  })
+
+  it("maps unavailable capability failures to HTTP 503", () => {
+    expect(capabilityError(502, "upstream failed")).toMatchObject({
+      statusCode: 503,
+      status: "UNAVAILABLE",
+    })
+  })
+
+  it("rejects capability output declared above the response limit", async () => {
+    const response = new Response("small", {
+      headers: { "Content-Length": String(A2A_MAX_RESPONSE_BYTES + 1) },
+    })
+    await expect(readA2ACapabilityText(response)).rejects.toMatchObject({
+      statusCode: 503,
+      status: "UNAVAILABLE",
+    })
   })
 })

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -13,6 +13,7 @@ import {
   resolveA2AEndpoint,
   validateA2ARequestHeaders,
 } from "../src/lib/a2a"
+import { decodeExternalTargetPath, validateExternalDocumentationUrl } from "../src/lib/external"
 
 const originalFetch = globalThis.fetch
 
@@ -106,7 +107,9 @@ describe("A2A HTTP+JSON service", () => {
     const internalUrl = new URL(externalEndpoint, "https://sosumi.ai")
     expect(internalUrl.search).toBe("")
     expect(internalUrl.hash).toBe("")
-    expect(decodeURIComponent(internalUrl.pathname.slice("/external/".length))).toBe(externalTarget)
+    const decodedTarget = decodeExternalTargetPath(internalUrl.pathname)
+    expect(decodedTarget).toBe(externalTarget.replace("#overview", ""))
+    expect(validateExternalDocumentationUrl(decodedTarget).search).toBe("?language=swift")
   })
 
   it("requires the protocol version advertised by the Agent Card", () => {
@@ -297,6 +300,25 @@ describe("A2A HTTP+JSON service", () => {
       "PUSH_NOTIFICATION_NOT_SUPPORTED",
       "UNSUPPORTED_OPERATION",
     ])
+  })
+
+  it("validates and reports the ListTasks page size", async () => {
+    const headers = { "A2A-Version": A2A_PROTOCOL_VERSION }
+    const bindings = { ASSETS: env.ASSETS, NODE_ENV: "development" }
+    const [selected, tooSmall, tooLarge, malformed] = await Promise.all([
+      app.request("https://sosumi.ai/tasks?pageSize=10", { headers }, bindings),
+      app.request("https://sosumi.ai/tasks?pageSize=0", { headers }, bindings),
+      app.request("https://sosumi.ai/tasks?pageSize=101", { headers }, bindings),
+      app.request("https://sosumi.ai/tasks?pageSize=ten", { headers }, bindings),
+    ])
+
+    await expect(selected.json()).resolves.toMatchObject({ pageSize: 10, totalSize: 0 })
+    for (const response of [tooSmall, tooLarge, malformed]) {
+      expect(response.status).toBe(400)
+      await expect(response.json()).resolves.toMatchObject({
+        error: { code: 400, status: "INVALID_ARGUMENT" },
+      })
+    }
   })
 
   it("maps unavailable capability failures to HTTP 503", () => {

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -49,19 +49,43 @@ describe("A2A HTTP+JSON service", () => {
     expect(result.message.contextId).toBeTruthy()
   })
 
-  it("preserves context and honors text/plain output negotiation", async () => {
+  it("preserves context for Markdown responses", async () => {
     const result = await handleA2AMessage(
       {
         ...userMessage("Find Apple documentation about Swift actors", {
           contextId: "conversation-1",
         }),
-        configuration: { acceptedOutputModes: ["text/plain"] },
+        configuration: { acceptedOutputModes: ["text/markdown"] },
       },
       async () => "Search results",
     )
 
     expect(result.message.contextId).toBe("conversation-1")
-    expect(result.message.parts[0]?.mediaType).toBe("text/plain")
+    expect(result.message.parts[0]?.mediaType).toBe("text/markdown")
+  })
+
+  it("rejects plain-only output negotiation instead of mislabeling Markdown", async () => {
+    const response = await app.request(
+      "https://sosumi.ai/message:send",
+      {
+        method: "POST",
+        headers: {
+          "A2A-Version": A2A_PROTOCOL_VERSION,
+          "Content-Type": A2A_MEDIA_TYPE,
+        },
+        body: JSON.stringify({
+          ...userMessage("Fetch /documentation/swiftui/view"),
+          configuration: { acceptedOutputModes: ["text/plain"] },
+        }),
+      },
+      { ASSETS: env.ASSETS, NODE_ENV: "development" },
+    )
+
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as {
+      error: { details: Array<{ reason: string }> }
+    }
+    expect(body.error.details[0]?.reason).toBe("CONTENT_TYPE_NOT_SUPPORTED")
   })
 
   it("normalizes natural-language searches and supported fetch targets", () => {

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -55,7 +55,7 @@ describe("Agent discovery endpoints", () => {
         identifier: PUBLISHER_DID,
       }),
     )
-    expect(catalog.entries).toHaveLength(2)
+    expect(catalog.entries).toHaveLength(3)
 
     for (const entry of catalog.entries) {
       expect(entry.identifier).toMatch(
@@ -70,10 +70,18 @@ describe("Agent discovery endpoints", () => {
 
     expect(catalog.entries.map((entry) => entry.type)).toEqual([
       "application/mcp-server-card+json",
+      "application/a2a-agent-card+json",
       'text/markdown; profile="urn:air:agent-skills"',
     ])
 
     const skillEntry = catalog.entries.find((entry) => entry.type.startsWith("text/markdown"))
+    const a2aEntry = catalog.entries.find(
+      (entry) => entry.type === "application/a2a-agent-card+json",
+    )
+    expect(a2aEntry).toMatchObject({
+      identifier: `urn:air:${PUBLISHER_DOMAIN}:agent:documentation`,
+      url: `${PUBLISHER_ORIGIN}/.well-known/agent-card.json`,
+    })
     expect(skillEntry).toMatchObject({
       identifier: `urn:air:${PUBLISHER_DOMAIN}:skill:${SKILL_NAME}`,
       url: `${PUBLISHER_ORIGIN}/.well-known/agent-skills/${SKILL_NAME}/SKILL.md`,
@@ -223,7 +231,6 @@ describe("Agent discovery endpoints", () => {
         url: string
         protocolVersion: string
         protocolBinding: string
-        transport: string
       }>
       capabilities: Record<string, unknown>
       skills: Array<{ id: string; name: string; description: string; tags: string[] }>
@@ -236,9 +243,8 @@ describe("Agent discovery endpoints", () => {
     expect(Array.isArray(card.supportedInterfaces)).toBe(true)
     expect(card.supportedInterfaces.length).toBeGreaterThan(0)
     expect(card.supportedInterfaces[0].url).toBe("https://sosumi.ai")
-    expect(card.supportedInterfaces[0].protocolVersion).toBeTruthy()
+    expect(card.supportedInterfaces[0].protocolVersion).toBe("1.0")
     expect(card.supportedInterfaces[0].protocolBinding).toBe("HTTP+JSON")
-    expect(card.supportedInterfaces[0].transport).toBe("HTTP+JSON")
 
     expect(card.capabilities).toBeTypeOf("object")
 

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -247,6 +247,7 @@ describe("Agent discovery endpoints", () => {
     expect(card.supportedInterfaces[0].protocolBinding).toBe("HTTP+JSON")
 
     expect(card.capabilities).toBeTypeOf("object")
+    expect(card.defaultOutputModes).toEqual(["text/markdown"])
 
     expect(Array.isArray(card.skills)).toBe(true)
     expect(card.skills.length).toBeGreaterThan(0)

--- a/tests/agent-discovery.test.ts
+++ b/tests/agent-discovery.test.ts
@@ -233,6 +233,7 @@ describe("Agent discovery endpoints", () => {
         protocolBinding: string
       }>
       capabilities: Record<string, unknown>
+      defaultOutputModes: string[]
       skills: Array<{ id: string; name: string; description: string; tags: string[] }>
     }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,7 +21,8 @@
       "/",
       "/.well-known/agent-card.json",
       "/.well-known/agent-skills/*",
-      "/.well-known/security.txt"
+      "/.well-known/security.txt",
+      "/message:send"
     ]
   },
   "observability": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,7 +22,11 @@
       "/.well-known/agent-card.json",
       "/.well-known/agent-skills/*",
       "/.well-known/security.txt",
-      "/message:send"
+      "/message:send",
+      "/message:stream",
+      "/tasks",
+      "/tasks/*",
+      "/extendedAgentCard"
     ]
   },
   "observability": {


### PR DESCRIPTION
Follow-up to #104 

Implements a stateless A2A 1.0 HTTP+JSON message endpoint backed by Sosumi’s existing search and documentation capabilities. Updates the Agent Card and restores the now-invocable A2A entry to the ARD catalog. Adds request validation, protocol error responses, Worker routing, and integration coverage.