### PR TITLE
Bump version to 1.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nshipster/sosumi",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nshipster/sosumi",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "@hono/mcp": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nshipster/sosumi",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Making Apple docs AI-readable",
   "license": "MIT",
   "author": "NSHipster",


### PR DESCRIPTION
Version bump for the v1.0.9 release (#104, #105, #106, #107, #108).